### PR TITLE
Scaffold techne Claude skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "techne",
+  "description": "Development marketplace for the techne skills plugin.",
+  "owner": {
+    "name": "lynxlangya",
+    "email": "lynxlangya@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "techne",
+      "description": "A curated skills plugin for practical AI-era craft, judgment, and delivery.",
+      "version": "0.1.0",
+      "source": "./",
+      "author": {
+        "name": "lynxlangya",
+        "email": "lynxlangya@gmail.com"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "techne",
+  "description": "A curated skills plugin for practical AI-era craft, judgment, and delivery.",
+  "version": "0.1.0",
+  "author": {
+    "name": "lynxlangya",
+    "email": "lynxlangya@gmail.com"
+  },
+  "homepage": "https://github.com/lynxlangya/techne",
+  "repository": "https://github.com/lynxlangya/techne",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "agents",
+    "claude-code",
+    "workflows",
+    "judgment",
+    "craft"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ Ancient Greek for **craft · skill · art** — the practical know-how of *makin
 
 Skills and agents for the AI era.
 
+Install: techne is a Claude Code plugin scaffold; add this repository as a local
+marketplace or plugin directory after cloning. See [WORKFLOW.md](WORKFLOW.md)
+for the delivery process and [ROADMAP.md](ROADMAP.md) for the product map.
+
 <sub>技艺。古希腊语 τέχνη，是 “technique / technology” 的共同词根，指「知道怎么做」的实践之知。读作「忒克涅 / TEK-nee」。</sub>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,72 @@
+# Roadmap
+
+techne is a curated skill library for practical AI-era craft: moves that improve
+how an AI collaborator investigates, judges, writes, codes, and ships.
+
+## Quality Bar
+
+Every skill must be a forcing function for a move the model can make but often
+skips. A skill earns its place by improving behavior under pressure, not by
+reciting knowledge the model already has.
+
+Prefer skills that:
+
+- Install a concrete check, move, or stop condition.
+- Address a repeated failure pattern.
+- Have an empirical acceptance test.
+- Fill a gap in the platform or do an existing move sharper than superpowers.
+
+Avoid skills that:
+
+- Repackage generic advice.
+- Duplicate built-in Claude Code or superpowers behavior without a sharper bar.
+- Depend on one private project unless that dependency is isolated as reference
+  material.
+- Need industry expertise the maintainer cannot judge.
+
+## Audience x Jobs Map
+
+`general`:
+
+- interrogate
+- research
+- simplify
+- explain
+- decide
+
+`coding`:
+
+- debug
+- trace
+- review-diff
+
+`writing`:
+
+- structural-edit
+- tighten
+- voice-match
+- fact-pass
+
+`social`:
+
+- hook
+- repurpose
+- angle
+
+`finance`:
+
+- global-alpha-style vertical analysis
+
+## Seeding Principle
+
+Seed only audiences where the maintainer can personally judge quality:
+`coding`, `writing`, `social`, `finance`, and `general`.
+
+Other industries stay as placeholders until they are judgeable by the maintainer
+or contributed by someone who can own the quality bar.
+
+## Profiles, Not Branches
+
+Audiences are bundles and example sets over one flat skill library. They are not
+filesystem branches. Keep `skills/<name>/SKILL.md` flat, and track audience,
+sequence, and product packaging here.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,62 @@
+# Skills
+
+`skills/` is the source of truth for techne skill bodies. Each skill is a
+tool-neutral asset packaged by thin host-specific skins.
+
+## Layout
+
+Use a flat directory per skill:
+
+```text
+skills/
+  <name>/
+    SKILL.md
+    eval.md        # optional
+    scripts/       # optional
+    reference.md   # optional
+```
+
+Do not create category folders such as `skills/coding/` or `skills/writing/`.
+Audience, category, and product sequencing belong in `ROADMAP.md`, not in the
+filesystem.
+
+## Skill Body
+
+`SKILL.md` is the asset. Keep it independent of Claude Code, Codex, or any other
+host unless a section is explicitly marked as host-specific reference material.
+The same body should be usable through one Claude skin, one Codex skin, or future
+skins without becoming separate products.
+
+Every real techne skill should force a move the model would otherwise skip. Do
+not add skills that only recite general knowledge or clone a built-in platform
+capability without a sharper acceptance test.
+
+## Eval Convention
+
+Add `eval.md` for real skills. It should state:
+
+- The baseline prompt or pressure case.
+- The failure pattern observed without the skill.
+- The with-skill behavior expected.
+- The pass bar and how it will be judged.
+- Any cases where the skill should not fire.
+
+This follows `WORKFLOW.md`: empirical validation starts with the first real
+skill, not with this scaffold.
+
+## Optional Support Files
+
+Use support files only when needed:
+
+- `scripts/` for helpers the model can execute.
+- `reference.md` for longer background that should not live in the always-loaded
+  top of `SKILL.md`.
+- Examples or templates when they materially improve compliance.
+
+Do not commit empty support folders.
+
+## One Body, Two Skins
+
+The Claude plugin skin lives in `.claude-plugin/`. A Codex skin is intentionally
+deferred until the Codex skill format is verified. Both should point at this
+single `skills/` library rather than forking skill bodies.

--- a/skills/_template/SKILL.md
+++ b/skills/_template/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: _template
+description: Internal authoring template and manual canary. Copy this directory to start a new techne skill.
+disable-model-invocation: true
+---
+
+# Skill Title
+
+Use this file as the starting point for a new techne skill. Keep the skill body
+tool-neutral: the guidance here should make sense outside any one host, with
+tool-specific loading handled by plugin manifests.
+
+## Quality Bar
+
+A techne skill must force a move the model can make but often skips. It is not a
+place to restate common knowledge, collect vague advice, or duplicate what the
+platform or superpowers already handles well.
+
+Before authoring, identify:
+
+- The skipped move this skill forces.
+- The failure pattern it prevents.
+- The cases where the skill should not apply.
+- The observable improvement expected when the skill is present.
+
+## When To Use
+
+State the triggering situation in concrete terms. Prefer user intents, task
+conditions, and failure signals over broad domain labels.
+
+## Instructions
+
+Write the smallest set of instructions that reliably forces the move. Use direct
+commands, checks, and stop conditions. Avoid product-specific paths, local tool
+names, or host-only features unless they are documented as optional references.
+
+## Validation
+
+Each real skill should include an `eval.md` alongside `SKILL.md`. The eval file
+records the empirical acceptance test from `WORKFLOW.md`: baseline behavior,
+with-skill behavior, what counts as improvement, and the pass bar.
+
+For scaffold-only or template changes, direct mechanical validation is enough.
+
+## Supporting Files
+
+Optional files live next to `SKILL.md` when they remove noise from the main
+skill:
+
+- `eval.md` for the empirical acceptance test.
+- `scripts/` for executable helpers the model may run.
+- `reference.md` for longer material loaded only when needed.
+
+Do not add empty support folders. Add them only when the skill actually needs
+them.


### PR DESCRIPTION
## Summary

Scaffolds techne as a Claude Code skills plugin shell, with no real skills yet.

Created:
- `.claude-plugin/plugin.json` for the Claude plugin manifest.
- `.claude-plugin/marketplace.json` for local marketplace installation.
- `skills/_template/SKILL.md` as the authoring template and manual canary.
- `skills/README.md` for flat, tool-neutral skill conventions.
- `ROADMAP.md` for the quality bar, audience map, seeding principle, and profiles-not-branches model.
- A minimal README install pointer linking to `WORKFLOW.md` and `ROADMAP.md`.

Closes #8

## Acceptance Self-Check

- [x] `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are valid JSON.
  - `node -e ...JSON.parse(...)` passed for both files.
- [x] Manifests conform to Claude Code plugin schema.
  - `claude plugin validate . --strict` passed for the marketplace manifest.
  - An isolated plugin copy containing `.claude-plugin/plugin.json` and `skills/_template/SKILL.md` passed `claude plugin validate <tmp> --strict`.
- [x] Local plugin loading works without plugin-load errors.
  - `claude --init-only --plugin-dir . --debug-file /tmp/techne-claude-init.log` exited 0.
  - Debug log showed `Loaded inline plugin from path: techne` and `Loaded 1 skills from plugin techne default directory`.
- [x] `_template` is discoverable as a plugin skill.
  - `claude --plugin-dir . plugin details techne` showed `Skills (1)  _template` and Agents/Hooks/MCP/LSP all `0`.
- [x] `_template` is mechanically excluded from auto-invocation.
  - `skills/_template/SKILL.md` uses the amended frontmatter, including `disable-model-invocation: true`.
- [x] `ROADMAP.md` and `skills/README.md` match the agreed design.
  - They document the forcing-function quality bar, audience x jobs map, seeding principle, flat `skills/<name>/SKILL.md`, `eval.md`, and one body / two skins.
- [x] Layout matches superpowers conventions.
  - Flat `skills/_template/SKILL.md`; plugin manifests under `.claude-plugin/`; no category folders.
- [x] Do-not-create list respected.
  - No `.codex-plugin/`, `agents/`, `hooks/`, MCP, build scripts, or empty category directories were created.
- [x] `git diff --cached --check` passed.
- [x] Secret-pattern scan over changed files found no matches.

## Validation Gap

I attempted real non-interactive model calls with `claude --plugin-dir . -p '/techne:_template'`, but this local environment returned Claude API `401 Invalid authentication credentials` before a model turn. The plugin load and `_template` discovery checks above ran without requiring a model call; Claude review should run the actual manual invocation in an authenticated Claude context.

## Review Handoff

Per `WORKFLOW.md`, this PR is ready for Claude review in two hats: faithful execution of the spec, and fresh-eyes quality review. Please do not merge until that review and the user merge gate pass.
