### PR TITLE
Add techne install matrix

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "techne",
+  "displayName": "techne",
+  "description": "A curated skills plugin for practical AI-era craft, judgment, and delivery.",
+  "version": "0.1.0",
+  "author": {
+    "name": "lynxlangya",
+    "email": "lynxlangya@gmail.com"
+  },
+  "homepage": "https://github.com/lynxlangya/techne",
+  "repository": "https://github.com/lynxlangya/techne",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "agents",
+    "cursor",
+    "workflows",
+    "judgment",
+    "craft"
+  ],
+  "skills": "./skills/"
+}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,97 @@
+# Install techne
+
+techne keeps one source of truth in `skills/`. Each target below either loads
+that directory through a thin native skin or installs the same skills through
+the Agent Skills CLI.
+
+## Claude Code
+
+Native plugin install:
+
+```text
+/plugin marketplace add lynxlangya/techne
+/plugin install techne@techne
+/reload-plugins
+```
+
+Use the skill as `/techne:viz`.
+
+Local development from a clone:
+
+```text
+/plugin marketplace add ./
+/plugin install techne@techne
+/reload-plugins
+```
+
+## Codex
+
+Codex uses Agent Skills for techne. This installs `viz` globally through the
+Skills CLI and makes it available to Codex.
+
+```bash
+npx skills add lynxlangya/techne --skill viz -a codex -g -y
+```
+
+## Cursor
+
+techne includes `.cursor-plugin/plugin.json` with `skills: "./skills/"` for
+Cursor's plugin manifest shape. Real Cursor native install is not verified in
+this repository yet.
+
+Agent Skills fallback:
+
+```bash
+npx skills add lynxlangya/techne --skill viz -a cursor -g -y
+```
+
+## Gemini CLI
+
+techne includes `gemini-extension.json`. Gemini CLI extensions auto-discover
+bundled `skills/`; this skin intentionally does not add always-on `GEMINI.md`
+context.
+
+```bash
+gemini extensions install https://github.com/lynxlangya/techne
+```
+
+Real Gemini install is deferred to an environment with Gemini CLI active.
+
+Agent Skills fallback:
+
+```bash
+npx skills add lynxlangya/techne --skill viz -a gemini-cli -g -y
+```
+
+## Kimi Code
+
+Kimi Code uses Agent Skills:
+
+```bash
+npx skills add lynxlangya/techne --skill viz -a kimi-code-cli -g -y
+```
+
+## Universal Agent Skills Fallback
+
+The npm package is `skills` from Vercel Labs. Install one techne skill into a
+supported agent:
+
+```bash
+npx skills add lynxlangya/techne --skill <name> -a <agent> -y
+```
+
+Useful agent ids include `claude-code`, `codex`, `cursor`, `gemini-cli`, and
+`kimi-code-cli`.
+
+Use `-g` for a global install, or omit it to install into the current project.
+
+## Version Touchpoints
+
+Keep these version fields in sync when releasing techne:
+
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `.cursor-plugin/plugin.json`
+- `gemini-extension.json`
+
+Current version: `0.1.0`.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Ancient Greek for **craft · skill · art** — the practical know-how of *makin
 
 Skills and agents for the AI era.
 
-Install: techne is a Claude Code plugin scaffold; add this repository as a local
-marketplace or plugin directory after cloning. See [WORKFLOW.md](WORKFLOW.md)
-for the delivery process and [ROADMAP.md](ROADMAP.md) for the product map.
+Install techne for Claude, Codex, Cursor, Gemini, Kimi, or another Agent Skills
+target with [INSTALL.md](INSTALL.md). See [WORKFLOW.md](WORKFLOW.md) for the
+delivery process and [ROADMAP.md](ROADMAP.md) for the product map.
 
 <sub>技艺。古希腊语 τέχνη，是 “technique / technology” 的共同词根，指「知道怎么做」的实践之知。读作「忒克涅 / TEK-nee」。</sub>
+
+<sub>安装方式见 [INSTALL.md](INSTALL.md)：Claude 原生插件，Codex/Kimi 等通过 Agent Skills，Cursor/Gemini 为薄皮。</sub>

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "techne",
+  "description": "A curated skills plugin for practical AI-era craft, judgment, and delivery.",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
Closes #12

## What changed

- Added `.cursor-plugin/plugin.json` as a thin Cursor manifest with `skills: "./skills/"` and no agents/commands/hooks.
- Added `gemini-extension.json` with only name/description/version; no `GEMINI.md` or `contextFileName`.
- Added `INSTALL.md` covering Claude native plugin install, Codex via Agent Skills, Cursor/Gemini/Kimi paths, universal `npx skills` fallback, and version touchpoints.
- Updated `README.md` with an install pointer while preserving the English + Chinese `<sub>` framing.

## Verified in this environment

- [x] JSON validity: `python3 -m json.tool` passed for `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json`.
- [x] Claude native plugin: `claude plugin validate . --strict` passed.
- [x] Claude discovery: `claude --plugin-dir . plugin details techne` shows `Skills (2)  _template, viz`.
- [x] Cursor manifest schema: fetched Cursor's published `plugin.schema.json` and validated `.cursor-plugin/plugin.json` with AJV.
- [x] Agent Skills CLI shape: `npx skills@1.5.10 add lynxlangya/techne --skill viz -a <agent> -g -y` worked in an isolated temp `HOME` for `codex`, `kimi-code-cli`, `cursor`, `gemini-cli`, and `claude-code`.
- [x] Route C guardrails: no `.codex-plugin/`, no `GEMINI.md`, no `contextFileName`, no `.techne/`, no copied skill bodies.
- [x] Version consistency: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`, and `gemini-extension.json` all remain `0.1.0`.
- [x] Hygiene: `git diff --check` passed; changed-file secret scan was clean.

## Spec-only / deferred validation

- Cursor native install is not claimed as verified here; this PR only validates the manifest against Cursor's published schema and documents the Agent Skills fallback.
- Gemini native extension install is not claimed as verified here; this PR checks the manifest against the official extension shape and documents native install as deferred to a Gemini CLI environment.
- Empirical skill quality remains outside this issue; this PR only adds install skins/docs over the existing shared `skills/` body.
