### PR TITLE
chore(plugin): rename marketplace to techne-dev (techne@techne-dev)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "techne",
+  "name": "techne-dev",
   "description": "Development marketplace for the techne skills plugin.",
   "owner": {
     "name": "lynxlangya",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ Native plugin install:
 
 ```text
 /plugin marketplace add lynxlangya/techne
-/plugin install techne@techne
+/plugin install techne@techne-dev
 /reload-plugins
 ```
 
@@ -20,7 +20,7 @@ Local development from a clone:
 
 ```text
 /plugin marketplace add ./
-/plugin install techne@techne
+/plugin install techne@techne-dev
 /reload-plugins
 ```
 


### PR DESCRIPTION
Light-path tweak from the install-docs review. Marketplace name equalled the plugin name → confusing `/plugin install techne@techne`. Rename the **marketplace** to `techne-dev` (plugin stays `techne`) so install reads `/plugin install techne@techne-dev`, matching superpowers (`superpowers-dev`) / Anthropic (`claude-plugins-official`) convention. Touches `.claude-plugin/marketplace.json` (name) + `INSTALL.md` (2 commands). Verified: `claude plugin validate --strict` passes.