### PR TITLE
Evolve viz into typed diagram router

### DIFF
--- a/skills/viz/SKILL.md
+++ b/skills/viz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: viz
-description: Draw a faithful architecture or structure diagram of a real codebase or project by scanning the actual repo, never guessing. Use for system architecture, draw the architecture, map this project, 画架构图.
+description: Draw a faithful architecture or structure diagram of a real codebase or project by scanning the actual repo, never guessing. Use for system architecture, request lifecycle, data model, state transitions, type structure, draw the architecture, map this project, 画架构图.
 ---
 
 # viz
@@ -10,40 +10,62 @@ real investigation before drawing.
 
 ## Forced Procedure
 
-1. **Find roots.** Enumerate top-level manifest, workspace, build, native,
-   container, edge, infra, and source-only signals before deciding shape. Use the
-   catalog in [reference.md](reference.md) when the project is not obvious.
-2. **Classify shape.** State one classification and cite evidence:
-   `single-frontend`, `single-backend`, `coupled-fullstack`, `monorepo`,
-   `library`, `native`, `native+edge`, `source-only code`, or `non-code`.
-3. **Apply the non-code decision.** Never declare non-code only because manifests
+1. **Route the request.** Choose one `diagramKind` from the table below. If the
+   user's intent fits multiple kinds, ask one short clarification instead of
+   guessing.
+2. **Find evidence for that kind.** For `architecture`, enumerate roots,
+   manifests, workspace/build/native/container/edge/infra/source-only signals.
+   For other kinds, find the bounded entrypoint, schema, state enum, workflow,
+   or module/type namespace before drawing.
+3. **Classify shape or scope.** For `architecture`, state one project shape and
+   cite evidence: `single-frontend`, `single-backend`, `coupled-fullstack`,
+   `monorepo`, `library`, `native`, `native+edge`, `source-only code`, or
+   `non-code`. For other kinds, state the bounded scope and the files that prove
+   it.
+4. **Apply the non-code decision.** Never declare non-code only because manifests
    are absent. First scan roots; then run a bounded source-extension/code-signal
    scan. If both are absent, or docs/vault signals clearly dominate, do not
-   fabricate an architecture. Draw the real top-level structure or ask what the
-   user wants. If source signals exist without manifests, classify as
-   `source-only code` and draw cautiously from real files.
-4. **Choose top-level components.** Use real packages, modules, apps, services,
-   and infrastructure units. Do not turn individual files into architecture
-   nodes unless the project is genuinely source-only and tiny.
-5. **Draw real edges.** Every edge must come from a file read: imports between
-   packages, build/workspace dependencies, HTTP/RPC clients, compose networks,
-   queues, database access, or edge bindings. No unsupported edges.
-6. **Enforce altitude.** Target 12-15 top-level nodes. If there are more, group
-   them in Mermaid `subgraph` blocks or create a drill-down diagram. The
-   validator/store helper has a node-count gate; do not route around it.
-7. **Mark provenance.** Solid Mermaid edges mean read-from-code. Dashed edges
-   (`-. infer .->`) mean inference. Record sources in stored metadata and, when
-   useful, in comments near the diagram.
+   fabricate a code diagram. Draw the real top-level structure or ask what the
+   user wants.
+5. **Draw only evidenced relationships.** Use the evidence contract for the
+   selected kind. Every node, participant, entity, state, type, and edge/message
+   must come from a file read.
+6. **Enforce complexity gates.** Keep `architecture` at 12-15 top-level nodes by
+   default. For other kinds, use the validator's participant/message,
+   entity/relationship, state/transition, or type/member limits. Split into
+   drill-down diagrams when needed.
+7. **Mark provenance.** Solid relationships mean read-from-code. Dashed
+   relationships mean inference only where Mermaid has a clean weak/dashed form.
+   For ER/class diagrams, exclude inferred relationships by default unless the
+   user explicitly asks for likely edges; if included, label them visibly.
 8. **Emit, validate, store, build viewer, open when interactive.** Write Mermaid
    source first, validate it, store it with `scripts/store_viz.py`, always build
    the self-contained viewer, and only open it when the session is interactive.
+
+## Diagram Routing
+
+| User intent | `diagramKind` | Mermaid `type` | Evidence focus |
+| --- | --- | --- | --- |
+| Project architecture, module/service/package topology | `architecture` | `flowchart` / `graph` | Manifests, workspaces, imports, services, bindings, infra edges. |
+| Request lifecycle, command/job flow, actor conversation | `interaction` | `sequenceDiagram` | Entrypoint, ordered calls/messages, handlers, clients, queues. |
+| Tables, entities, persistence relationships | `data-model` | `erDiagram` | Schema, migrations, ORM/entity declarations, foreign keys, associations. |
+| Status/order/task/review lifecycle | `state-model` | `stateDiagram-v2` / `stateDiagram` | Status constants, state machines, reducers, guards, transition handlers. |
+| Classes, interfaces, structs, protocols, bounded type structure | `type-structure` | `classDiagram` | Type declarations, inheritance, implementation, composition, public method groups. |
+
+Examples:
+
+- "map this project" -> `architecture`.
+- "show how login request flows" -> `interaction`.
+- "draw the database relationships" -> `data-model`.
+- "how does order status change" -> `state-model`.
+- "show the public types in this module" -> `type-structure`.
 
 ## Script Usage
 
 - Validate Mermaid and altitude:
   `node skills/viz/scripts/validate-mermaid.mjs diagram.md --max-nodes 15`
 - Store a diagram in a target project:
-  `python3 skills/viz/scripts/store_viz.py --project /path/to/project --name architecture --title "Architecture" --diagram diagram.md --shape monorepo --type flowchart --source src/app.ts --coverage grounded --node-count 8`
+  `python3 skills/viz/scripts/store_viz.py --project /path/to/project --name login-flow --title "Login flow" --diagram diagram.md --shape monorepo --diagram-kind interaction --type sequenceDiagram --source src/app.ts --coverage grounded`
 - Build the self-contained viewer, opening it only when interactive:
   `python3 skills/viz/scripts/build_viewer.py --project /path/to/project --open`
 
@@ -54,8 +76,11 @@ current working directory, or an ancestor directory.
 ## Stop Conditions
 
 - Stop and ask if you cannot inspect the project files.
+- Stop and ask if the requested diagram kind is ambiguous.
 - Stop before drawing unsupported architecture for a non-code project.
-- Stop before storing a diagram that fails syntax validation or the altitude
+- Stop before drawing a non-architecture diagram without a bounded entrypoint,
+  schema, status lifecycle, or module/type scope.
+- Stop before storing a diagram that fails syntax validation or a complexity
   gate.
 - Do not create `.techne/` content inside this repository while authoring the
   skill itself.

--- a/skills/viz/eval.md
+++ b/skills/viz/eval.md
@@ -6,24 +6,30 @@ Claude context.
 
 ## Test Set
 
-Use four maintainer-private local repos:
+Use maintainer-private local repos or bounded areas that cover the supported
+diagram kinds where feasible:
 
-- A web+edge workspace.
-- A JS workspace app.
-- A non-code notes vault.
-- A native+edge hybrid, especially Swift/Xcode.
+- Architecture: a web+edge workspace, JS workspace app, or native+edge hybrid.
+- Interaction: one request, command, job, login, sync, or async flow.
+- Data model: one schema, migration set, or ORM/entity area.
+- State model: one status lifecycle, reducer, workflow, or state machine.
+- Type structure: one bounded module/package with public types.
+- Non-code guard: a notes/docs vault.
 
 Do not commit private paths, generated diagrams, or `.techne/` output.
 
 ## Baseline
 
-Ask the model to draw the architecture without `viz`.
+Ask the model to draw the requested diagram without `viz`.
 
 Record:
 
+- Wrong diagram-kind choice.
 - Fabricated nodes.
-- Fabricated edges.
+- Fabricated edges, messages, relationships, transitions, or type links.
 - Incorrect project shape.
+- Incorrect temporal order, schema relationship, lifecycle transition, or type
+  relationship.
 - Diagram readability.
 - Render/validation failures.
 
@@ -31,24 +37,38 @@ Record:
 
 Invoke `viz` on the same repos. The skill must:
 
+- Route to the correct `diagramKind`, or ask one clarification when ambiguous.
 - Classify shape with evidence.
-- Avoid fabricating nodes or edges.
+- State bounded scope for non-architecture diagrams.
+- Avoid fabricating nodes, participants, entities, states, types, edges,
+  messages, relationships, or transitions.
 - Use the non-code branch for the notes vault.
 - Avoid false-refusing manifest-less code.
-- Keep top-level altitude readable.
+- Keep complexity within the relevant gate or split the diagram.
 - Validate and store the diagram.
 
 ## Metrics
 
-- Fabrication rate: target approximately zero fabricated nodes/edges.
+- Routing correctness: selected `diagramKind` matches user intent and evidence.
+- Fabrication rate: target approximately zero fabricated diagram elements.
 - Shape correctness: project classification matches evidence.
-- Altitude: top-level nodes stay within cap or are grouped/split.
+- Architecture: modules/services/boundaries match source evidence.
+- Interaction: message order matches the code path.
+- Data model: entities and relationships match schema evidence.
+- State model: states, transitions, and triggers match code evidence.
+- Type structure: inheritance, implementation, composition, and public method
+  groups match declarations.
+- Complexity: diagrams stay within cap or split/narrow scope.
 - Renderability: Mermaid validates and viewer renders.
 - Improvement: with-`viz` beats baseline on at least one metric.
 
 ## Pass Bar
 
 Pass only if with-`viz` has approximately zero fabrications, correct shape,
-readable altitude, successful validation/rendering, visible improvement over
-baseline on at least one metric, and passes the non-code refuse-to-fabricate
-case without false-refusing source-only code.
+correct diagram-kind routing, readable complexity, successful
+validation/rendering, visible improvement over baseline on at least one metric,
+and passes the non-code refuse-to-fabricate case without false-refusing
+source-only code.
+
+Codex can run only the mechanical checks. Claude and the maintainer must judge
+whether the diagrams are faithful to private/local source evidence.

--- a/skills/viz/reference.md
+++ b/skills/viz/reference.md
@@ -87,30 +87,88 @@ and draw only what can be supported from those files.
 - `source-only code`: source files exist but no recognized manifest/build root.
 - `non-code`: no code roots/source signals, or docs/vault dominance.
 
-## Mermaid Type Decision Table
+## Typed Mermaid Decision Table
 
-| Need | MVP decision | Reason |
-| --- | --- | --- |
-| Codebase architecture / component map | Use `flowchart TD` | Fits packages, services, apps, infra, and provenance edges. |
-| Drill-down of one grouped component | Use another `flowchart TD` | Keeps the same validation and altitude gate. |
-| Call-level behavior | Defer | Call graph is out of scope for the MVP. |
-| Database entities | Defer | ER diagrams are out of scope for the MVP. |
-| Classes/types | Defer | Class diagrams are out of scope for the MVP. |
-| Request lifecycle or temporal interaction | Defer | Sequence diagrams are out of scope for the MVP. |
-| C4-style architecture | Defer | Mermaid C4 is not part of this MVP. |
+| Diagram kind | User phrasing | Evidence to read | Mermaid type | Complexity gate | Stop or ask when |
+| --- | --- | --- | --- | --- | --- |
+| `architecture` | "map this project", "draw architecture", "what are the modules/services" | Root catalog, workspace manifests, imports, service clients, infra/container/edge bindings | `flowchart` / `graph` | 12-15 top-level nodes by default unless grouped/split | Project is non-code, evidence is missing, or broad scope needs splitting |
+| `interaction` | "how does this request/job/command flow", "login lifecycle" | Router/controller/handler entrypoints, service calls, clients, jobs, queues, callbacks | `sequenceDiagram` | 8 participants and 20 messages by default | No bounded entrypoint, temporal order cannot be read, or static dependencies are being mistaken for messages |
+| `data-model` | "database relationships", "entities", "schema" | Migrations, DDL, ORM models, Prisma/Drizzle/ActiveRecord/Ecto/entity definitions, foreign keys, associations | `erDiagram` | 12 entities and 20 relationships by default | Relationships come only from naming guesses or schema scope is too broad |
+| `state-model` | "status lifecycle", "state transitions", "workflow states" | Enums/status constants, reducers, state machines, transition handlers, guards, workflow definitions | `stateDiagram-v2` / `stateDiagram` | 12 states and 20 transitions by default | Transitions or triggers cannot be tied to code evidence |
+| `type-structure` | "class/type/interface structure", "protocol hierarchy" | Class/interface/protocol/struct/type declarations, inheritance, implementation, composition, public method groups | `classDiagram` | 12 types and 30 relationship/member lines by default | Module/package scope is unbounded or relationships are inferred from names only |
 
-## Flowchart Conventions
+Unsupported in this version: Gantt, pie, journey, timeline, mindmap, Git graph,
+C4, quadrant, requirement, packet, sankey, and arbitrary Mermaid diagrams.
+
+## Evidence Catalogs
+
+### Architecture
+
+Use packages, modules, apps, services, infra, containers, build/workspace
+dependencies, imports between packages, HTTP/RPC clients, queues, database
+access, and edge bindings. Do not turn individual files into architecture nodes
+unless the project is genuinely source-only and tiny.
+
+### Interaction
+
+Look for the bounded entrypoint first:
+
+- Web/API: routes, controllers, middleware, handlers, RPC procedure files.
+- Jobs/commands: CLI entrypoints, scheduled handlers, queue consumers, workers.
+- Clients/messages: service clients, fetch/RPC calls, event emitters, queue
+  producers, callbacks.
+
+Sequence messages must be ordered from code reads. Participants are real
+actors, services, modules, or external systems found in code.
+
+### Data Model
+
+Look for schema evidence:
+
+- SQL migrations, DDL files, `schema.sql`.
+- ORM/entity files such as Prisma, Drizzle, ActiveRecord, Ecto, SQLAlchemy,
+  Django models, TypeORM, Entity Framework, Rails models.
+- Foreign keys, explicit references, join tables, association declarations.
+
+Exclude inferred relationships by default. If the user asks for likely edges,
+label them visibly and record why they are inferred.
+
+### State Model
+
+Look for explicit lifecycle evidence:
+
+- Enum/status constants and allowed values.
+- Reducers, transition maps, workflow definitions, state machines.
+- Guard functions, command handlers, transition side effects.
+
+Transitions need source and trigger evidence. If Mermaid cannot distinguish an
+inferred transition visually, label it with `inferred:`.
+
+### Type Structure
+
+Keep scope bounded to one module/package unless the user asks otherwise. Read:
+
+- Classes, interfaces, protocols, structs, traits, type aliases.
+- Inheritance and implementation declarations.
+- Composition fields and public method groups.
+
+Exclude inferred type relationships by default. If likely/inferred edges are
+requested, label them visibly.
+
+## Provenance Conventions
 
 Represent provenance:
 
-- Solid edge: `A --> B` for read-from-code facts.
-- Dashed edge: `A -. infer .-> B` for inference.
-- Edge labels: name protocol, import, binding, or source fact briefly.
+- Solid relationship/message: read-from-code fact.
+- Dashed relationship/message: inference only where the Mermaid type supports a
+  clean weak/dashed form.
+- Annotated inference: use labels such as `inferred:` when Mermaid has no clean
+  dashed/weak relationship syntax.
+- Edge/message labels: name protocol, import, binding, trigger, method, or
+  source fact briefly.
 - Comments: use `%% source: path/to/file` near relevant parts when helpful.
 - Metadata: rely on `.index.json` for full source file lists and coverage.
 
 Use `subgraph` for grouping when top-level nodes exceed the cap. If grouping
 would hide important structure, split into a drill-down diagram and mark
 metadata `split: true`.
-
-Do not use call graph, ER, class, sequence, or C4 diagrams for this MVP.

--- a/skills/viz/scripts/build_viewer.py
+++ b/skills/viz/scripts/build_viewer.py
@@ -19,6 +19,15 @@ SVG_PAN_ZOOM = VIEWER_ROOT / "svg-pan-zoom.min.js"
 
 FENCE_PATTERN = re.compile(r"```(?:mermaid|mmd)\s*\n([\s\S]*?)```", re.IGNORECASE)
 SCRIPT_END_PATTERN = re.compile(r"</(script)", re.IGNORECASE)
+TYPE_TO_KIND = {
+    "flowchart": "architecture",
+    "graph": "architecture",
+    "sequenceDiagram": "interaction",
+    "erDiagram": "data-model",
+    "stateDiagram-v2": "state-model",
+    "stateDiagram": "state-model",
+    "classDiagram": "type-structure",
+}
 
 
 def extract_mermaid(text: str) -> str:
@@ -56,6 +65,8 @@ def load_diagrams(viz_dir: Path, index: dict) -> list[dict]:
             raise SystemExit(f"Indexed diagram file is empty after Mermaid extraction: {target}")
         record = dict(item)
         record["file"] = file_name
+        record["type"] = record.get("type") or "flowchart"
+        record["diagramKind"] = record.get("diagramKind") or TYPE_TO_KIND.get(record["type"], "unknown")
         record["raw"] = raw
         record["source"] = source
         record["exportName"] = safe_export_name(target.stem or f"diagram-{position + 1}")

--- a/skills/viz/scripts/store_viz.py
+++ b/skills/viz/scripts/store_viz.py
@@ -6,6 +6,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 
+COMPATIBLE_TYPES = {
+    "architecture": {"flowchart", "graph"},
+    "interaction": {"sequenceDiagram"},
+    "data-model": {"erDiagram"},
+    "state-model": {"stateDiagram-v2", "stateDiagram"},
+    "type-structure": {"classDiagram"},
+}
+SUPPORTED_TYPES = {mermaid_type for mermaid_types in COMPATIBLE_TYPES.values() for mermaid_type in mermaid_types}
+
 def slugify(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
     return slug or "diagram"
@@ -26,6 +35,20 @@ def load_index(index_path: Path) -> dict:
     return json.loads(index_path.read_text(encoding="utf-8"))
 
 
+def resolve_diagram_kind(diagram_kind, mermaid_type):
+    if mermaid_type not in SUPPORTED_TYPES:
+        allowed = ", ".join(sorted(SUPPORTED_TYPES))
+        raise SystemExit(f"Unsupported --type {mermaid_type}; expected one of: {allowed}")
+    if diagram_kind is None:
+        if mermaid_type in {"flowchart", "graph"}:
+            return "architecture"
+        raise SystemExit(f"--diagram-kind is required when --type is {mermaid_type}")
+    if mermaid_type not in COMPATIBLE_TYPES[diagram_kind]:
+        allowed = ", ".join(sorted(COMPATIBLE_TYPES[diagram_kind]))
+        raise SystemExit(f"--diagram-kind {diagram_kind} is not compatible with --type {mermaid_type}; expected one of: {allowed}")
+    return diagram_kind
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Store a techne viz diagram in a target project.")
     parser.add_argument("--project", required=True, type=Path)
@@ -33,6 +56,11 @@ def main() -> None:
     parser.add_argument("--title", required=True)
     parser.add_argument("--diagram", required=True, type=Path)
     parser.add_argument("--shape", required=True)
+    parser.add_argument(
+        "--diagram-kind",
+        choices=sorted(COMPATIBLE_TYPES),
+        help="Cognitive diagram kind; required for non-architecture Mermaid types.",
+    )
     parser.add_argument("--type", default="flowchart")
     parser.add_argument("--source", action="append", default=[])
     parser.add_argument("--coverage", default="grounded")
@@ -45,7 +73,8 @@ def main() -> None:
     project = args.project.resolve()
     if not project.is_dir():
         raise SystemExit(f"Project directory does not exist: {project}")
-    if args.node_count and args.node_count > args.max_nodes and not (args.grouped or args.split):
+    diagram_kind = resolve_diagram_kind(args.diagram_kind, args.type)
+    if diagram_kind == "architecture" and args.node_count and args.node_count > args.max_nodes and not (args.grouped or args.split):
         raise SystemExit(
             f"Node count {args.node_count} exceeds max {args.max_nodes}; group into subgraphs or mark --grouped/--split"
         )
@@ -64,6 +93,7 @@ def main() -> None:
         {
             "title": args.title,
             "file": output.name,
+            "diagramKind": diagram_kind,
             "type": args.type,
             "sourceFiles": args.source,
             "generatedAt": datetime.now(timezone.utc).isoformat(),

--- a/skills/viz/scripts/validate-mermaid.mjs
+++ b/skills/viz/scripts/validate-mermaid.mjs
@@ -4,31 +4,90 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 
-const MAX_DEFAULT = 15;
+const LIMITS = {
+  maxNodes: 15,
+  maxParticipants: 8,
+  maxMessages: 20,
+  maxEntities: 12,
+  maxRelationships: 20,
+  maxStates: 12,
+  maxTransitions: 20,
+  maxTypes: 12,
+  maxMemberLines: 30,
+};
+
+const TYPE_TO_KIND = {
+  flowchart: 'architecture',
+  graph: 'architecture',
+  sequencediagram: 'interaction',
+  erdiagram: 'data-model',
+  'statediagram-v2': 'state-model',
+  statediagram: 'state-model',
+  classdiagram: 'type-structure',
+};
+
+const CANONICAL_TYPES = {
+  flowchart: 'flowchart',
+  graph: 'graph',
+  sequencediagram: 'sequenceDiagram',
+  erdiagram: 'erDiagram',
+  'statediagram-v2': 'stateDiagram-v2',
+  statediagram: 'stateDiagram',
+  classdiagram: 'classDiagram',
+};
 
 function usage() {
-  console.error('Usage: validate-mermaid.mjs <diagram.md|diagram.mmd> [--max-nodes 15] [--grouped|--split]');
+  console.error(`Usage: validate-mermaid.mjs <diagram.md|diagram.mmd> [options]
+
+Options:
+  --max-nodes N            Architecture top-level node limit (default 15)
+  --grouped                Allow over-budget architecture via grouping
+  --split                  Allow over-budget architecture via split diagrams
+  --max-participants N     Sequence participant limit (default 8)
+  --max-messages N         Sequence message limit (default 20)
+  --max-entities N         ER entity limit (default 12)
+  --max-relationships N    ER relationship limit (default 20)
+  --max-states N           State count limit (default 12)
+  --max-transitions N      State transition limit (default 20)
+  --max-types N            Class/type count limit (default 12)
+  --max-member-lines N     Class relationship/member line limit (default 30)`);
 }
 
 function parseArgs(argv) {
-  const args = { maxNodes: MAX_DEFAULT, grouped: false, split: false, file: null };
+  const args = { ...LIMITS, grouped: false, split: false, file: null };
+  const numeric = new Set(Object.keys(LIMITS).map((key) => `--${key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)}`));
+  const byFlag = {
+    '--max-nodes': 'maxNodes',
+    '--max-participants': 'maxParticipants',
+    '--max-messages': 'maxMessages',
+    '--max-entities': 'maxEntities',
+    '--max-relationships': 'maxRelationships',
+    '--max-states': 'maxStates',
+    '--max-transitions': 'maxTransitions',
+    '--max-types': 'maxTypes',
+    '--max-member-lines': 'maxMemberLines',
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--max-nodes') {
-      args.maxNodes = Number(argv[++i]);
-    } else if (arg === '--grouped') {
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    }
+    if (arg === '--grouped') {
       args.grouped = true;
     } else if (arg === '--split') {
       args.split = true;
+    } else if (numeric.has(arg)) {
+      const value = Number(argv[++i]);
+      if (!Number.isInteger(value) || value < 1) throw new Error(`Invalid value for ${arg}`);
+      args[byFlag[arg]] = value;
     } else if (!args.file) {
       args.file = arg;
     } else {
       throw new Error(`Unknown argument: ${arg}`);
     }
   }
-  if (!args.file || !Number.isInteger(args.maxNodes) || args.maxNodes < 1) {
-    throw new Error('Missing diagram file or invalid --max-nodes');
-  }
+  if (!args.file) throw new Error('Missing diagram file');
   return args;
 }
 
@@ -76,14 +135,32 @@ function extractMermaid(text) {
   return (fence ? fence[1] : text).trim();
 }
 
-function assertFlowchart(source) {
-  const firstLine = source
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line && !line.startsWith('%%'));
-  if (!firstLine || !/^(flowchart|graph)\b/i.test(firstLine)) {
-    throw new Error('Only Mermaid flowchart/graph diagrams are supported by the viz MVP');
+function contentLines(source) {
+  return source.split(/\r?\n/).map((raw, index) => ({ raw, line: raw.trim(), index }));
+}
+
+function isIgnorable(line) {
+  return !line || line.startsWith('%%');
+}
+
+function detectType(source) {
+  const first = contentLines(source).find(({ line }) => !isIgnorable(line));
+  if (!first) throw new Error('Diagram is empty');
+  const match = first.line.match(/^([A-Za-z][\w-]*)\b/);
+  if (!match) throw new Error(`Unsupported Mermaid type: ${first.line}`);
+  const key = match[1].toLowerCase();
+  if (!TYPE_TO_KIND[key]) {
+    throw new Error(`Unsupported Mermaid type: ${match[1]}; supported: flowchart, graph, sequenceDiagram, erDiagram, stateDiagram-v2, stateDiagram, classDiagram`);
   }
+  return {
+    headerIndex: first.index,
+    diagramKind: TYPE_TO_KIND[key],
+    mermaidType: CANONICAL_TYPES[key],
+  };
+}
+
+function bodyLines(source, headerIndex) {
+  return contentLines(source).filter(({ index, line }) => index > headerIndex && !isIgnorable(line));
 }
 
 function stripStrings(line) {
@@ -145,19 +222,225 @@ function countTopLevelNodes(source) {
   return nodes.size;
 }
 
+function failClosed(line, reason) {
+  throw new Error(`syntax is renderable but not countable by techne: ${reason}: ${line}; simplify, split, or narrow scope`);
+}
+
+function assertLimit(value, max, label, action = 'split, simplify, or narrow scope') {
+  if (value > max) {
+    throw new Error(`${label} count ${value} exceeds max ${max}; ${action}`);
+  }
+}
+
+function countSequence(source, headerIndex, args) {
+  const participants = new Set();
+  let messages = 0;
+  for (const { line } of bodyLines(source, headerIndex)) {
+    if (/^(loop|alt|else|opt|par|and|critical|option|break|box|end|rect|create|destroy|activate|deactivate)\b/i.test(line)) {
+      failClosed(line, 'unsupported sequence control or lifecycle syntax');
+    }
+    if (/^(autonumber|title|accTitle|accDescr)\b/i.test(line)) continue;
+    const declaration = line.match(/^(participant|actor)\s+([A-Za-z_][\w.]*)(?:\s+as\s+.+)?$/i);
+    if (declaration) {
+      participants.add(declaration[2]);
+      continue;
+    }
+    const note = line.match(/^Note\s+(?:over|right of|left of)\s+(.+?)\s*:/i);
+    if (note) {
+      for (const id of note[1].split(',').map((item) => item.trim()).filter(Boolean)) {
+        if (!/^[A-Za-z_][\w.]*$/.test(id)) failClosed(line, 'unsupported sequence note participant syntax');
+        participants.add(id);
+      }
+      continue;
+    }
+    const message = line.match(/^([A-Za-z_][\w.]*)\s*-{1,2}(?:>>|>|x|\))\s*([A-Za-z_][\w.]*)\s*:/);
+    if (message) {
+      participants.add(message[1]);
+      participants.add(message[2]);
+      messages += 1;
+      continue;
+    }
+    failClosed(line, 'unsupported sequence syntax');
+  }
+  assertLimit(participants.size, args.maxParticipants, 'Participant');
+  assertLimit(messages, args.maxMessages, 'Message');
+  return {
+    counts: { participants: participants.size, messages },
+    limits: { maxParticipants: args.maxParticipants, maxMessages: args.maxMessages },
+  };
+}
+
+function countEr(source, headerIndex, args) {
+  const entities = new Set();
+  let relationships = 0;
+  let inEntity = null;
+  for (const { line } of bodyLines(source, headerIndex)) {
+    if (inEntity) {
+      if (line === '}') {
+        inEntity = null;
+        continue;
+      }
+      if (/[{}]/.test(line)) failClosed(line, 'unsupported ER entity block syntax');
+      continue;
+    }
+    const block = line.match(/^([A-Za-z_][\w-]*)\s*\{$/);
+    if (block) {
+      entities.add(block[1]);
+      inEntity = block[1];
+      continue;
+    }
+    if (line === '}') failClosed(line, 'unmatched ER entity block close');
+    const relationship = line.match(/^([A-Za-z_][\w-]*)\s+[|}{o]+\s*(?:--|\.\.)\s*[|}{o]+\s+([A-Za-z_][\w-]*)\s*:/);
+    if (relationship) {
+      entities.add(relationship[1]);
+      entities.add(relationship[2]);
+      relationships += 1;
+      continue;
+    }
+    failClosed(line, 'unsupported ER syntax');
+  }
+  if (inEntity) failClosed(inEntity, 'unclosed ER entity block');
+  assertLimit(entities.size, args.maxEntities, 'Entity');
+  assertLimit(relationships, args.maxRelationships, 'Relationship');
+  return {
+    counts: { entities: entities.size, relationships },
+    limits: { maxEntities: args.maxEntities, maxRelationships: args.maxRelationships },
+  };
+}
+
+function addState(states, id) {
+  if (id !== '[*]') states.add(id);
+}
+
+function countState(source, headerIndex, args) {
+  const states = new Set();
+  let transitions = 0;
+  for (const { line } of bodyLines(source, headerIndex)) {
+    if (/^direction\s+(TB|BT|RL|LR)$/i.test(line)) continue;
+    if (/^state\s+["']/i.test(line) || /<<[^>]+>>/.test(line) || line === '--' || /[{}]/.test(line)) {
+      failClosed(line, 'unsupported nested/composite/fork state syntax');
+    }
+    const stateDecl = line.match(/^state\s+([A-Za-z_][\w.-]*)$/i);
+    if (stateDecl) {
+      states.add(stateDecl[1]);
+      continue;
+    }
+    const transition = line.match(/^(\[\*\]|[A-Za-z_][\w.-]*)\s*-->\s*(\[\*\]|[A-Za-z_][\w.-]*)(?:\s*:\s*.+)?$/);
+    if (transition) {
+      addState(states, transition[1]);
+      addState(states, transition[2]);
+      transitions += 1;
+      continue;
+    }
+    const simpleState = line.match(/^([A-Za-z_][\w.-]*)(?:\s*:\s*.+)?$/);
+    if (simpleState) {
+      states.add(simpleState[1]);
+      continue;
+    }
+    failClosed(line, 'unsupported state syntax');
+  }
+  assertLimit(states.size, args.maxStates, 'State');
+  assertLimit(transitions, args.maxTransitions, 'Transition');
+  return {
+    counts: { states: states.size, transitions },
+    limits: { maxStates: args.maxStates, maxTransitions: args.maxTransitions },
+  };
+}
+
+function countClass(source, headerIndex, args) {
+  const types = new Set();
+  let relationshipLines = 0;
+  let memberLines = 0;
+  let inClass = null;
+  for (const { line } of bodyLines(source, headerIndex)) {
+    if (/^namespace\b/i.test(line) || /<<[^>]+>>/.test(line) || /~/.test(line)) {
+      failClosed(line, 'unsupported class namespace, annotation, or generic syntax');
+    }
+    if (inClass) {
+      if (line === '}') {
+        inClass = null;
+        continue;
+      }
+      if (/[{}]/.test(line)) failClosed(line, 'unsupported class block syntax');
+      memberLines += 1;
+      continue;
+    }
+    const block = line.match(/^class\s+([A-Za-z_][\w.-]*)\s*\{$/i);
+    if (block) {
+      types.add(block[1]);
+      inClass = block[1];
+      continue;
+    }
+    const declaration = line.match(/^class\s+([A-Za-z_][\w.-]*)$/i);
+    if (declaration) {
+      types.add(declaration[1]);
+      continue;
+    }
+    if (line === '}') failClosed(line, 'unmatched class block close');
+    const relationship = line.match(/^([A-Za-z_][\w.-]*)\s+(<\|--|<\|\.\.|\*--|o--|-->|--|\.\.>|\.\.\|>|\.\.)\s+([A-Za-z_][\w.-]*)(?:\s*:.*)?$/);
+    if (relationship) {
+      types.add(relationship[1]);
+      types.add(relationship[3]);
+      relationshipLines += 1;
+      continue;
+    }
+    const member = line.match(/^([A-Za-z_][\w.-]*)\s*:\s*.+$/);
+    if (member) {
+      types.add(member[1]);
+      memberLines += 1;
+      continue;
+    }
+    failClosed(line, 'unsupported class syntax');
+  }
+  if (inClass) failClosed(inClass, 'unclosed class block');
+  const relationshipOrMemberLines = relationshipLines + memberLines;
+  assertLimit(types.size, args.maxTypes, 'Type');
+  assertLimit(relationshipOrMemberLines, args.maxMemberLines, 'Relationship/member line');
+  return {
+    counts: { types: types.size, relationshipLines, memberLines, relationshipOrMemberLines },
+    limits: { maxTypes: args.maxTypes, maxMemberLines: args.maxMemberLines },
+  };
+}
+
+function countDiagram(source, detected, args, text) {
+  if (detected.diagramKind === 'architecture') {
+    const topLevelNodes = countTopLevelNodes(source);
+    const groupedOrSplit = args.grouped || args.split || /techne-viz:\s*(grouped|split)\s*=\s*true/i.test(text);
+    if (topLevelNodes > args.maxNodes && !groupedOrSplit) {
+      throw new Error(`Top-level node count ${topLevelNodes} exceeds max ${args.maxNodes}; group into subgraphs or mark grouped/split`);
+    }
+    return {
+      counts: { topLevelNodes },
+      limits: { maxNodes: args.maxNodes },
+      groupedOrSplit,
+    };
+  }
+  if (detected.diagramKind === 'interaction') return { ...countSequence(source, detected.headerIndex, args), groupedOrSplit: false };
+  if (detected.diagramKind === 'data-model') return { ...countEr(source, detected.headerIndex, args), groupedOrSplit: false };
+  if (detected.diagramKind === 'state-model') return { ...countState(source, detected.headerIndex, args), groupedOrSplit: false };
+  if (detected.diagramKind === 'type-structure') return { ...countClass(source, detected.headerIndex, args), groupedOrSplit: false };
+  throw new Error(`Unsupported diagram kind: ${detected.diagramKind}`);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const text = fs.readFileSync(args.file, 'utf8');
   const source = extractMermaid(text);
-  assertFlowchart(source);
+  const detected = detectType(source);
   const mermaid = await loadMermaid(findNodeModules(process.cwd()));
   await mermaid.parse(source, { suppressErrors: false });
-  const topLevelNodes = countTopLevelNodes(source);
-  const bypass = args.grouped || args.split || /techne-viz:\s*(grouped|split)\s*=\s*true/i.test(text);
-  if (topLevelNodes > args.maxNodes && !bypass) {
-    throw new Error(`Top-level node count ${topLevelNodes} exceeds max ${args.maxNodes}; group into subgraphs or mark grouped/split`);
-  }
-  console.log(JSON.stringify({ ok: true, diagramType: 'flowchart', topLevelNodes, maxNodes: args.maxNodes, groupedOrSplit: bypass }));
+  const measured = countDiagram(source, detected, args, text);
+  const output = {
+    ok: true,
+    diagramKind: detected.diagramKind,
+    mermaidType: detected.mermaidType,
+    diagramType: detected.mermaidType,
+    counts: measured.counts,
+    limits: measured.limits,
+    groupedOrSplit: measured.groupedOrSplit,
+  };
+  Object.assign(output, measured.counts);
+  console.log(JSON.stringify(output));
 }
 
 main().catch((error) => {

--- a/skills/viz/scripts/viewer/template.html
+++ b/skills/viz/scripts/viewer/template.html
@@ -660,10 +660,27 @@ __TECHNE_SVG_PAN_ZOOM_JS__
           return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 14.5A8 8 0 1 1 9.5 4a6.2 6.2 0 0 0 10.5 10.5Z" /></svg>';
         }
 
+        function getMermaidType(item) {
+          return item.type || "flowchart";
+        }
+
+        function getDiagramKind(item) {
+          if (item.diagramKind) return item.diagramKind;
+          const mermaidType = getMermaidType(item);
+          if (mermaidType === "flowchart" || mermaidType === "graph") return "architecture";
+          if (mermaidType === "sequenceDiagram") return "interaction";
+          if (mermaidType === "erDiagram") return "data-model";
+          if (mermaidType === "stateDiagram-v2" || mermaidType === "stateDiagram") return "state-model";
+          if (mermaidType === "classDiagram") return "type-structure";
+          return "unknown";
+        }
+
         function renderList() {
           listEl.innerHTML = "";
           countEl.textContent = `${diagrams.length} ${diagrams.length === 1 ? "diagram" : "diagrams"}`;
           diagrams.forEach((item, index) => {
+            const diagramKind = getDiagramKind(item);
+            const mermaidType = getMermaidType(item);
             const button = document.createElement("button");
             button.type = "button";
             button.className = "diagram-item";
@@ -671,8 +688,8 @@ __TECHNE_SVG_PAN_ZOOM_JS__
             button.innerHTML = `
               <div class="diagram-title">${escapeHtml(item.title || item.file || "Untitled")}</div>
               <div class="diagram-detail">
-                <span class="badge">${escapeHtml(item.shape || "shape")}</span>
-                <span>${escapeHtml(item.type || "flowchart")}</span>
+                <span class="badge">${escapeHtml(diagramKind)}</span>
+                <span>${escapeHtml(mermaidType)}</span>
               </div>
             `;
             button.addEventListener("click", () => {
@@ -687,8 +704,9 @@ __TECHNE_SVG_PAN_ZOOM_JS__
         function renderMeta(item) {
           const sourceFiles = Array.isArray(item.sourceFiles) ? item.sourceFiles : [];
           const values = [
+            ["kind", getDiagramKind(item)],
             ["shape", item.shape],
-            ["type", item.type],
+            ["mermaid", getMermaidType(item)],
             ["coverage", item.coverage],
             ["nodes", item.nodeCount],
             ["generated", formatDate(item.generatedAt)],
@@ -730,7 +748,7 @@ __TECHNE_SVG_PAN_ZOOM_JS__
           destroyPanZoom();
           configureMermaid();
           titleEl.textContent = item.title || item.file || "Untitled diagram";
-          subtitleEl.textContent = `${item.shape || "unknown"} / ${item.type || "flowchart"}`;
+          subtitleEl.textContent = `${getDiagramKind(item)} / ${getMermaidType(item)}`;
           renderMeta(item);
           canvasEl.innerHTML = "";
           try {


### PR DESCRIPTION
Closes #18.

## What changed

- Updated `skills/viz/SKILL.md` into one user-facing `viz` skill with typed internal routing for `architecture`, `interaction`, `data-model`, `state-model`, and `type-structure`.
- Replaced the flowchart-only reference table with a typed decision table, evidence catalogs, complexity gates, stop/ask cases, and type-specific provenance guidance.
- Expanded `validate-mermaid.mjs` from flowchart-only validation to parse-only validation plus countable-subset counters for `flowchart`/`graph`, `sequenceDiagram`, `erDiagram`, `stateDiagram-v2`/`stateDiagram`, and `classDiagram`.
- Added `store_viz.py --diagram-kind` while preserving Mermaid `--type` and legacy flowchart behavior.
- Kept the viewer shared and added metadata fallback/display for `diagramKind` and Mermaid `type`.
- Updated `eval.md` with mechanical and empirical eval categories by diagram kind.

## Mechanical self-checks run

- JS/Python syntax:
  - `node --check skills/viz/scripts/validate-mermaid.mjs`
  - `PYTHONPYCACHEPREFIX=$(mktemp -d /tmp/techne-pycache-XXXXXX) python3 -m py_compile skills/viz/scripts/store_viz.py skills/viz/scripts/build_viewer.py`
- Validator T1 checks using temp `mermaid@11.15.0` + `jsdom@27.3.0`:
  - accepted valid examples for architecture `flowchart`, `sequenceDiagram`, `erDiagram`, `stateDiagram-v2`, and `classDiagram`.
  - rejected unsupported Mermaid type, malformed Mermaid, over-budget sequence/ER/state/class, over-budget flowchart, and an unsupported-but-renderable sequence `loop` shape.
  - confirmed existing flowchart altitude gate and `--grouped` bypass still work.
- Store/build T1 checks:
  - stored one example of each supported kind into a temp project with explicit `--diagram-kind` + Mermaid `--type`.
  - stored a legacy `--type flowchart` entry without `--diagram-kind`, treated as `architecture`.
  - repeated the legacy store command and confirmed `.gitignore` stayed idempotent with one `.techne/` line.
  - built a self-contained viewer containing all supported kinds.
- Browser/file T1 checks:
  - opened the generated viewer via `file://`.
  - clicked all 6 temp diagrams; each rendered an SVG with no canvas error.
  - DevTools console had no messages.
  - DevTools network showed only local `file://` HTML requests and no external loads.
  - static HTML payload check confirmed `diagramKind`, all supported Mermaid types, and the PNG export code path (`export-button` + `toBlob`) are present.
- Claude plugin checks:
  - `claude plugin validate . --strict`
  - `claude --bare --plugin-dir . plugin details techne` showed skills `_template` and `viz`.
- Repo hygiene:
  - `git diff --check`
  - diff secret scan for key/password/token patterns: no matches.
  - `git ls-files .techne '*/.techne/*'`: no tracked `.techne/` output.

## Deferred to Claude / maintainer review

- Empirical faithfulness on private/local repos for each kind: architecture, interaction, data model, state model, and type structure.
- Whether `viz` chooses the correct diagram kind without over-asking.
- Whether diagrams are faithful to source evidence and readable at the intended altitude.
- PNG visual fidelity beyond the static code-path presence check.

This is Codex execution plus mechanical self-check, not an independent Claude review.
