### PR TITLE
Enforce viz provenance gate

### DIFF
--- a/skills/viz/README-CN.md
+++ b/skills/viz/README-CN.md
@@ -56,7 +56,7 @@ npx skills update viz -g -y
 - 它选择的 `diagramKind`。
 - 项目形状或本次限定范围。
 - 画图前实际读取的证据文件。
-- 通过校验的 Mermaid 源码。
+- 带 `%% techne:source` / `%% techne:inferred` provenance 注释、并通过校验的 Mermaid 源码。
 - 目标项目里的 `.techne/viz/*.md`、`.index.json` 和 `index.html`。
 
 不要把 `.techne/` 提交进项目仓库。
@@ -133,12 +133,33 @@ npx skills update viz -g -y
 open .techne/viz/index.html
 ```
 
+## 脚本用法
+
+带目标项目校验 Mermaid，这样 provenance 会被真实检查：
+
+```bash
+node skills/viz/scripts/validate-mermaid.mjs diagram.md --project /path/to/project --max-nodes 15
+```
+
+写入目标项目。`store_viz.py` 会自己运行 validator，并派生
+`diagramKind`、`type`、`sourceFiles`、`coverage` 和 `nodeCount`；不要再传自报的
+source 或 coverage：
+
+```bash
+python3 skills/viz/scripts/store_viz.py \
+  --project /path/to/project \
+  --name login-flow \
+  --title "Login flow" \
+  --diagram diagram.md \
+  --shape monorepo
+```
+
 ## 结果检查
 
 测试时重点看：
 
 - 是否选对图表类型。
-- 节点和关系是否都有文件证据。
+- 每个节点、participant、entity、state、type、edge、message、relationship 或 transition 是否都有有效 provenance。
 - 有没有编造模块、调用、状态、实体或类型关系。
 - 图是否被控制在可读复杂度内。
 - Mermaid 是否通过校验。

--- a/skills/viz/README.md
+++ b/skills/viz/README.md
@@ -62,7 +62,8 @@ A good run should show:
 - The selected `diagramKind`.
 - The repository shape or bounded scope.
 - The evidence files read before drawing.
-- Mermaid source that passes validation.
+- Mermaid source with `%% techne:source` / `%% techne:inferred`
+  provenance comments that passes validation.
 - Stored output under `.techne/viz/` in the target project.
 - A self-contained `.techne/viz/index.html` viewer.
 
@@ -160,12 +161,34 @@ without a local server or network request:
 open .techne/viz/index.html
 ```
 
+## Script Usage
+
+Validate against a target project so provenance is enforced:
+
+```bash
+node skills/viz/scripts/validate-mermaid.mjs diagram.md --project /path/to/project --max-nodes 15
+```
+
+Store a diagram. `store_viz.py` runs the validator itself and derives
+`diagramKind`, `type`, `sourceFiles`, `coverage`, and `nodeCount`; do not pass
+self-reported source or coverage metadata:
+
+```bash
+python3 skills/viz/scripts/store_viz.py \
+  --project /path/to/project \
+  --name login-flow \
+  --title "Login flow" \
+  --diagram diagram.md \
+  --shape monorepo
+```
+
 ## What to Check
 
 When testing `viz`, judge the run by evidence, not by visual polish alone:
 
 - Did it pick the correct `diagramKind`?
-- Did it cite the files that prove the nodes and relationships?
+- Did every node, participant, entity, state, type, edge, message, relationship,
+  or transition have valid provenance?
 - Did it avoid invented modules, messages, states, entities, or type links?
 - Did it keep the diagram readable or split the scope?
 - Did Mermaid validation pass?

--- a/skills/viz/SKILL.md
+++ b/skills/viz/SKILL.md
@@ -34,10 +34,16 @@ real investigation before drawing.
    default. For other kinds, use the validator's participant/message,
    entity/relationship, state/transition, or type/member limits. Split into
    drill-down diagrams when needed.
-7. **Mark provenance.** Solid relationships mean read-from-code. Dashed
-   relationships mean inference only where Mermaid has a clean weak/dashed form.
-   For ER/class diagrams, exclude inferred relationships by default unless the
-   user explicitly asks for likely edges; if included, label them visibly.
+7. **Mark provenance.** Add render-neutral comments for every element before
+   storing:
+   `%% techne:source <elementRef> <path>[#<symbol>]` or, for relationship-like
+   elements only, `%% techne:inferred <relationshipRef> <reason>`. Entity-like
+   elements always need verified `techne:source`; relationship-like elements
+   need file+symbol proof unless explicitly inferred with sourced endpoints.
+   Use `actor` for human sequence participants so the actor path-only allowance
+   is mechanically scoped. Solid relationships mean read-from-code. Dashed or
+   labeled relationships mean inference only where the selected Mermaid type
+   supports it.
 8. **Emit, validate, store, build viewer, open when interactive.** Write Mermaid
    source first, validate it, store it with `scripts/store_viz.py`, always build
    the self-contained viewer, and only open it when the session is interactive.
@@ -63,9 +69,9 @@ Examples:
 ## Script Usage
 
 - Validate Mermaid and altitude:
-  `node skills/viz/scripts/validate-mermaid.mjs diagram.md --max-nodes 15`
+  `node skills/viz/scripts/validate-mermaid.mjs diagram.md --project /path/to/project --max-nodes 15`
 - Store a diagram in a target project:
-  `python3 skills/viz/scripts/store_viz.py --project /path/to/project --name login-flow --title "Login flow" --diagram diagram.md --shape monorepo --diagram-kind interaction --type sequenceDiagram --source src/app.ts --coverage grounded`
+  `python3 skills/viz/scripts/store_viz.py --project /path/to/project --name login-flow --title "Login flow" --diagram diagram.md --shape monorepo`
 - Build the self-contained viewer, opening it only when interactive:
   `python3 skills/viz/scripts/build_viewer.py --project /path/to/project --open`
 
@@ -80,7 +86,7 @@ current working directory, or an ancestor directory.
 - Stop before drawing unsupported architecture for a non-code project.
 - Stop before drawing a non-architecture diagram without a bounded entrypoint,
   schema, status lifecycle, or module/type scope.
-- Stop before storing a diagram that fails syntax validation or a complexity
-  gate.
+- Stop before storing a diagram that fails syntax validation, provenance
+  validation, or a complexity gate.
 - Do not create `.techne/` content inside this repository while authoring the
   skill itself.

--- a/skills/viz/eval.md
+++ b/skills/viz/eval.md
@@ -72,3 +72,33 @@ source-only code.
 
 Codex can run only the mechanical checks. Claude and the maintainer must judge
 whether the diagrams are faithful to private/local source evidence.
+
+## Mechanical Provenance Fixtures
+
+Run these with temporary fixture projects only. Do not commit generated
+`.techne/` output.
+
+| # | Fixture | Expected |
+| --- | --- | --- |
+| A | Fabricated diagram with `techne:source` paths that do not exist | Validator exit 1 with missing paths; store refuses. |
+| B | Real paths but fabricated symbols | Validator exit 1 with `symbol_not_found`. |
+| C | Valid diagram with zero annotations | Validator exit 1 with uncovered elements. |
+| D | Small real fixture project, every element annotated with real path+symbol | Validator exit 0; store succeeds; index has computed coverage and derived `sourceFiles`. |
+| E | Fixture D plus one `techne:inferred` edge whose endpoints are sourced | Passes with `inferred: 1` in coverage. |
+| F | Annotation references an element ID not present in the diagram | Validator exit 1. |
+| G | Path escapes project root | Validator exit 1. |
+| H | Valid five-kind fixtures without `--project` | Still validate with `provenance.verified: false`. |
+| I | All elements marked only as `techne:inferred` | Validator exit 1 because entity-like elements require source. |
+| J | Inferred edge whose endpoint lacks a verified source | Validator exit 1. |
+| K | Architecture node cites an existing directory | Passes as `pathVerified`. |
+| L | Architecture edge cites a directory | Validator exit 1. |
+| M | Non-architecture element cites a directory | Validator exit 1. |
+| N | Store called with stale `--node-count` | Rejected as an unknown argument. |
+| O | `node` or validator dependencies missing | Store exits non-zero with an actionable message. |
+| P | Unknown `%% techne:*` directive | Validator exit 1. |
+| Q | Every element cites existing `README.md` path-only | Validator exit 1 because relationship-like elements require `#symbol`. |
+| R | Relationship-like `techne:source` without `#symbol` | Validator exit 1. |
+| S | `actor User` cites a real route/handler file path-only | Passes as `pathVerified`. |
+| T | `participant BillingService` cites a broad real file without symbol | Validator exit 1. |
+| U | Store called with stale `--diagram-kind` or `--type` | Rejected as unknown arguments. |
+| V | `sequenceDiagram` stored successfully | Index records `diagramKind: interaction` and `type: sequenceDiagram` from validator output. |

--- a/skills/viz/reference.md
+++ b/skills/viz/reference.md
@@ -157,17 +157,47 @@ requested, label them visibly.
 
 ## Provenance Conventions
 
-Represent provenance:
+Provenance is mandatory when validating or storing against a project root. Use
+render-neutral Mermaid comments:
 
-- Solid relationship/message: read-from-code fact.
-- Dashed relationship/message: inference only where the Mermaid type supports a
-  clean weak/dashed form.
-- Annotated inference: use labels such as `inferred:` when Mermaid has no clean
-  dashed/weak relationship syntax.
-- Edge/message labels: name protocol, import, binding, trigger, method, or
-  source fact briefly.
-- Comments: use `%% source: path/to/file` near relevant parts when helpful.
-- Metadata: rely on `.index.json` for full source file lists and coverage.
+```mermaid
+%% techne:source <elementRef> <path>[#<symbol>]
+%% techne:inferred <relationshipRef> <reason>
+```
+
+`<elementRef>` is a node, participant, entity, state, or type ID. Relationship
+refs use the written ordered pair: `<from>-><to>`. State transitions may use
+`[*]` literally, for example `[*]->Queued`.
+
+Citation strength rules:
+
+| Citation form | Valid for |
+| --- | --- |
+| Directory, no symbol | `architecture` nodes only. |
+| File path-only | `architecture` nodes and sequence participants declared with `actor`. |
+| File `#symbol` | Everything; required for all relationship-like elements and all non-architecture entity-like elements except `actor` participants. |
+
+Symbols are split at the first `#`, matched literally and case-sensitively in
+the cited file. Use real evidence tokens such as function names, route names,
+package names, dependency strings, config keys, table names, enum cases, or type
+names. Do not use broad common words merely because they grep.
+
+External systems cite the file that proves the dependency, such as a client
+initializer, manifest, container config, or binding. Relationship-like evidence
+still needs `#symbol`, for example `docker-compose.yml#postgres`.
+
+Human participants in sequence diagrams should be declared with `actor` and may
+cite the entrypoint that serves them path-only. Service/module participants must
+use `participant` or implicit participant syntax and require `#symbol`.
+
+`techne:inferred` is valid only for relationship-like elements whose endpoints
+are already sourced. Exclude inferred ER/class relationships by default unless
+the user explicitly asks for likely edges; when included, label them visibly.
+Ordinary `%%` comments are ignored, but unknown `%% techne:*` directives fail
+validation.
+
+Computed `.index.json` metadata comes from the validator: `sourceFiles`,
+`coverage`, `nodeCount`, `diagramKind`, and `type` are derived, not declared.
 
 Use `subgraph` for grouping when top-level nodes exceed the cap. If grouping
 would hide important structure, split into a drill-down diagram and mark

--- a/skills/viz/scripts/store_viz.py
+++ b/skills/viz/scripts/store_viz.py
@@ -2,18 +2,16 @@
 import argparse
 import json
 import re
+import shutil
+import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 
-COMPATIBLE_TYPES = {
-    "architecture": {"flowchart", "graph"},
-    "interaction": {"sequenceDiagram"},
-    "data-model": {"erDiagram"},
-    "state-model": {"stateDiagram-v2", "stateDiagram"},
-    "type-structure": {"classDiagram"},
-}
-SUPPORTED_TYPES = {mermaid_type for mermaid_types in COMPATIBLE_TYPES.values() for mermaid_type in mermaid_types}
+SCRIPT_ROOT = Path(__file__).resolve().parent
+VALIDATOR = SCRIPT_ROOT / "validate-mermaid.mjs"
+
 
 def slugify(value: str) -> str:
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
@@ -35,18 +33,87 @@ def load_index(index_path: Path) -> dict:
     return json.loads(index_path.read_text(encoding="utf-8"))
 
 
-def resolve_diagram_kind(diagram_kind, mermaid_type):
-    if mermaid_type not in SUPPORTED_TYPES:
-        allowed = ", ".join(sorted(SUPPORTED_TYPES))
-        raise SystemExit(f"Unsupported --type {mermaid_type}; expected one of: {allowed}")
-    if diagram_kind is None:
-        if mermaid_type in {"flowchart", "graph"}:
-            return "architecture"
-        raise SystemExit(f"--diagram-kind is required when --type is {mermaid_type}")
-    if mermaid_type not in COMPATIBLE_TYPES[diagram_kind]:
-        allowed = ", ".join(sorted(COMPATIBLE_TYPES[diagram_kind]))
-        raise SystemExit(f"--diagram-kind {diagram_kind} is not compatible with --type {mermaid_type}; expected one of: {allowed}")
-    return diagram_kind
+def validator_command(args: argparse.Namespace, project: Path) -> list[str]:
+    node = shutil.which("node")
+    if not node:
+        raise SystemExit(
+            "Node.js is required to store techne viz diagrams because store_viz.py "
+            "runs validate-mermaid.mjs with provenance enforcement. Install Node.js "
+            "and mermaid@11.15.0/jsdom, or set TECHNE_VIZ_NODE_MODULES."
+        )
+    if not VALIDATOR.is_file():
+        raise SystemExit(f"Mermaid validator not found next to store_viz.py: {VALIDATOR}")
+    command = [
+        node,
+        str(VALIDATOR),
+        str(args.diagram),
+        "--project",
+        str(project),
+        "--max-nodes",
+        str(args.max_nodes),
+        "--max-participants",
+        str(args.max_participants),
+        "--max-messages",
+        str(args.max_messages),
+        "--max-entities",
+        str(args.max_entities),
+        "--max-relationships",
+        str(args.max_relationships),
+        "--max-states",
+        str(args.max_states),
+        "--max-transitions",
+        str(args.max_transitions),
+        "--max-types",
+        str(args.max_types),
+        "--max-member-lines",
+        str(args.max_member_lines),
+    ]
+    if args.grouped:
+        command.append("--grouped")
+    if args.split:
+        command.append("--split")
+    return command
+
+
+def parse_validator_payload(text: str) -> dict | None:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def run_validator(args: argparse.Namespace, project: Path) -> dict:
+    result = subprocess.run(
+        validator_command(args, project),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        payload = parse_validator_payload(stderr) or parse_validator_payload(stdout)
+        if payload:
+            raise SystemExit("Mermaid validation failed:\n" + json.dumps(payload, indent=2, ensure_ascii=False))
+        message = stderr or stdout or f"validator exited with status {result.returncode}"
+        raise SystemExit("Mermaid validation failed:\n" + message)
+    payload = parse_validator_payload(result.stdout)
+    if not payload:
+        raise SystemExit("Mermaid validation failed: validator did not return JSON")
+    return payload
+
+
+def derived_node_count(validation: dict) -> int | None:
+    counts = validation.get("counts") or {}
+    for key in ("topLevelNodes", "participants", "entities", "states", "types"):
+        value = counts.get(key)
+        if isinstance(value, int):
+            return value
+    return None
 
 
 def main() -> None:
@@ -56,16 +123,15 @@ def main() -> None:
     parser.add_argument("--title", required=True)
     parser.add_argument("--diagram", required=True, type=Path)
     parser.add_argument("--shape", required=True)
-    parser.add_argument(
-        "--diagram-kind",
-        choices=sorted(COMPATIBLE_TYPES),
-        help="Cognitive diagram kind; required for non-architecture Mermaid types.",
-    )
-    parser.add_argument("--type", default="flowchart")
-    parser.add_argument("--source", action="append", default=[])
-    parser.add_argument("--coverage", default="grounded")
-    parser.add_argument("--node-count", type=int)
     parser.add_argument("--max-nodes", type=int, default=15)
+    parser.add_argument("--max-participants", type=int, default=8)
+    parser.add_argument("--max-messages", type=int, default=20)
+    parser.add_argument("--max-entities", type=int, default=12)
+    parser.add_argument("--max-relationships", type=int, default=20)
+    parser.add_argument("--max-states", type=int, default=12)
+    parser.add_argument("--max-transitions", type=int, default=20)
+    parser.add_argument("--max-types", type=int, default=12)
+    parser.add_argument("--max-member-lines", type=int, default=30)
     parser.add_argument("--grouped", action="store_true")
     parser.add_argument("--split", action="store_true")
     args = parser.parse_args()
@@ -73,11 +139,7 @@ def main() -> None:
     project = args.project.resolve()
     if not project.is_dir():
         raise SystemExit(f"Project directory does not exist: {project}")
-    diagram_kind = resolve_diagram_kind(args.diagram_kind, args.type)
-    if diagram_kind == "architecture" and args.node_count and args.node_count > args.max_nodes and not (args.grouped or args.split):
-        raise SystemExit(
-            f"Node count {args.node_count} exceeds max {args.max_nodes}; group into subgraphs or mark --grouped/--split"
-        )
+    validation = run_validator(args, project)
     viz_dir = project / ".techne" / "viz"
     viz_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,13 +155,14 @@ def main() -> None:
         {
             "title": args.title,
             "file": output.name,
-            "diagramKind": diagram_kind,
-            "type": args.type,
-            "sourceFiles": args.source,
+            "diagramKind": validation.get("diagramKind"),
+            "type": validation.get("mermaidType") or validation.get("diagramType"),
+            "sourceFiles": validation.get("sourceFiles") or [],
             "generatedAt": datetime.now(timezone.utc).isoformat(),
             "shape": args.shape,
-            "coverage": args.coverage,
-            "nodeCount": args.node_count,
+            "coverage": validation.get("coverage"),
+            "nodeCount": derived_node_count(validation),
+            "topLevelNodes": (validation.get("counts") or {}).get("topLevelNodes"),
             "grouped": args.grouped,
             "split": args.split,
         }
@@ -112,4 +175,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except BrokenPipeError:
+        sys.exit(1)

--- a/skills/viz/scripts/validate-mermaid.mjs
+++ b/skills/viz/scripts/validate-mermaid.mjs
@@ -36,10 +36,21 @@ const CANONICAL_TYPES = {
   classdiagram: 'classDiagram',
 };
 
+const ID_SCAN_RE = /[A-Za-z_][\w.:-]*/g;
+const WORD_CHAR_RE = /[A-Za-z0-9_]/;
+
+class ProvenanceError extends Error {
+  constructor(payload) {
+    super('provenance validation failed');
+    this.payload = payload;
+  }
+}
+
 function usage() {
   console.error(`Usage: validate-mermaid.mjs <diagram.md|diagram.mmd> [options]
 
 Options:
+  --project PATH           Verify techne provenance against a project root
   --max-nodes N            Architecture top-level node limit (default 15)
   --grouped                Allow over-budget architecture via grouping
   --split                  Allow over-budget architecture via split diagrams
@@ -54,7 +65,7 @@ Options:
 }
 
 function parseArgs(argv) {
-  const args = { ...LIMITS, grouped: false, split: false, file: null };
+  const args = { ...LIMITS, grouped: false, split: false, file: null, project: null };
   const numeric = new Set(Object.keys(LIMITS).map((key) => `--${key.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`)}`));
   const byFlag = {
     '--max-nodes': 'maxNodes',
@@ -77,6 +88,10 @@ function parseArgs(argv) {
       args.grouped = true;
     } else if (arg === '--split') {
       args.split = true;
+    } else if (arg === '--project') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --project');
+      args.project = value;
     } else if (numeric.has(arg)) {
       const value = Number(argv[++i]);
       if (!Number.isInteger(value) || value < 1) throw new Error(`Invalid value for ${arg}`);
@@ -185,43 +200,6 @@ function normalizeEdges(line) {
     .replace(/==[^=<>]*==>/g, '==>');
 }
 
-function collectIds(fragment, ids) {
-  const ignored = new Set(['classDef', 'class', 'style', 'linkStyle', 'click']);
-  const matches = fragment.match(/[A-Za-z_][\w:-]*/g) || [];
-  for (const id of matches) {
-    if (!ignored.has(id)) ids.add(id);
-  }
-}
-
-function countTopLevelNodes(source) {
-  const nodes = new Set();
-  let depth = 0;
-  const lines = source.split(/\r?\n/);
-  for (const raw of lines) {
-    const trimmed = raw.trim();
-    if (!trimmed || trimmed.startsWith('%%')) continue;
-    if (/^subgraph\b/i.test(trimmed)) {
-      depth += 1;
-      continue;
-    }
-    if (/^end\b/i.test(trimmed)) {
-      depth = Math.max(0, depth - 1);
-      continue;
-    }
-    if (/^(flowchart|graph)\b/i.test(trimmed) || depth > 0) continue;
-    const line = normalizeEdges(stripNodeText(stripStrings(trimmed)));
-    if (/^(classDef|class|style|linkStyle|click)\b/.test(line)) continue;
-    if (/(-->|---|==>|~~~|<-->|o--|--o|x--|--x)/.test(line)) {
-      const fragments = line.split(/\s*(?:-->|---|==>|~~~|<-->|o--|--o|x--|--x)\s*/);
-      for (const fragment of fragments) collectIds(fragment, nodes);
-    } else {
-      const match = line.trim().match(/^([A-Za-z_][\w:-]*)/);
-      if (match) nodes.add(match[1]);
-    }
-  }
-  return nodes.size;
-}
-
 function failClosed(line, reason) {
   throw new Error(`syntax is renderable but not countable by techne: ${reason}: ${line}; simplify, split, or narrow scope`);
 }
@@ -232,47 +210,159 @@ function assertLimit(value, max, label, action = 'split, simplify, or narrow sco
   }
 }
 
-function countSequence(source, headerIndex, args) {
-  const participants = new Set();
+function uniqueSorted(values) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function elementMap(elements) {
+  return new Map(elements.map((element) => [element.ref, element]));
+}
+
+function relationshipRef(from, to) {
+  return `${from}->${to}`;
+}
+
+function addEntity(entities, id, attrs = {}) {
+  if (id === '[*]') return;
+  const existing = entities.get(id);
+  if (!existing) {
+    entities.set(id, { ref: id, kind: 'entity', ...attrs });
+    return;
+  }
+  const merged = { ...existing, ...attrs };
+  if (existing.actor || attrs.actor) merged.actor = true;
+  if (existing.participantKind === 'actor' || attrs.participantKind === 'actor') {
+    merged.participantKind = 'actor';
+  }
+  entities.set(id, merged);
+}
+
+function addRelationship(relationships, from, to, attrs = {}) {
+  relationships.set(relationshipRef(from, to), {
+    ref: relationshipRef(from, to),
+    kind: 'relationship',
+    endpoints: [from, to],
+    ...attrs,
+  });
+}
+
+function tokenIds(fragment) {
+  const matches = fragment.match(ID_SCAN_RE) || [];
+  return matches.filter((id) => !['classDef', 'class', 'style', 'linkStyle', 'click'].includes(id));
+}
+
+function singleId(fragment, line) {
+  const ids = tokenIds(fragment);
+  if (ids.length !== 1) failClosed(line, 'unsupported architecture multi-node fragment');
+  return ids[0];
+}
+
+function analyzeArchitecture(source, headerIndex, args, text) {
+  const entities = new Map();
+  const relationships = new Map();
+  const topLevelNodes = new Set();
+  let depth = 0;
+  const edgeSplitRe = /\s*(?:<-->|-->|---|==>|~~~|o--|--o|x--|--x)\s*/;
+
+  for (const { line } of contentLines(source)) {
+    if (!line || line.startsWith('%%') || /^(flowchart|graph)\b/i.test(line)) continue;
+    if (/^subgraph\b/i.test(line)) {
+      depth += 1;
+      continue;
+    }
+    if (/^end\b/i.test(line)) {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (/^direction\s+(TB|BT|RL|LR)$/i.test(line)) continue;
+    if (/^(classDef|class|style|linkStyle|click)\b/i.test(line)) continue;
+
+    const normalized = normalizeEdges(stripNodeText(stripStrings(line)));
+    if (edgeSplitRe.test(normalized)) {
+      const fragments = normalized.split(edgeSplitRe).filter((fragment) => fragment.trim());
+      if (fragments.length < 2) failClosed(line, 'unsupported architecture edge syntax');
+      const ids = fragments.map((fragment) => singleId(fragment, line));
+      for (const id of ids) {
+        addEntity(entities, id, { diagramKind: 'architecture' });
+        if (depth === 0) topLevelNodes.add(id);
+      }
+      for (let i = 0; i < ids.length - 1; i += 1) {
+        addRelationship(relationships, ids[i], ids[i + 1], { diagramKind: 'architecture' });
+      }
+      continue;
+    }
+
+    const ids = tokenIds(normalized);
+    if (ids.length === 1) {
+      addEntity(entities, ids[0], { diagramKind: 'architecture' });
+      if (depth === 0) topLevelNodes.add(ids[0]);
+      continue;
+    }
+    failClosed(line, 'unsupported architecture syntax');
+  }
+
+  const groupedOrSplit = args.grouped || args.split || /techne-viz:\s*(grouped|split)\s*=\s*true/i.test(text);
+  if (topLevelNodes.size > args.maxNodes && !groupedOrSplit) {
+    throw new Error(`Top-level node count ${topLevelNodes.size} exceeds max ${args.maxNodes}; group into subgraphs or mark grouped/split`);
+  }
+  return {
+    counts: { topLevelNodes: topLevelNodes.size },
+    limits: { maxNodes: args.maxNodes },
+    groupedOrSplit,
+    elements: [...entities.values(), ...relationships.values()],
+  };
+}
+
+function analyzeSequence(source, headerIndex, args) {
+  const entities = new Map();
+  const relationships = new Map();
   let messages = 0;
   for (const { line } of bodyLines(source, headerIndex)) {
     if (/^(loop|alt|else|opt|par|and|critical|option|break|box|end|rect|create|destroy|activate|deactivate)\b/i.test(line)) {
       failClosed(line, 'unsupported sequence control or lifecycle syntax');
     }
     if (/^(autonumber|title|accTitle|accDescr)\b/i.test(line)) continue;
-    const declaration = line.match(/^(participant|actor)\s+([A-Za-z_][\w.]*)(?:\s+as\s+.+)?$/i);
+    const declaration = line.match(/^(participant|actor)\s+([A-Za-z_][\w.]*)((?:\s+as\s+.+)?)$/i);
     if (declaration) {
-      participants.add(declaration[2]);
+      addEntity(entities, declaration[2], {
+        diagramKind: 'interaction',
+        participantKind: declaration[1].toLowerCase(),
+        actor: declaration[1].toLowerCase() === 'actor',
+      });
       continue;
     }
     const note = line.match(/^Note\s+(?:over|right of|left of)\s+(.+?)\s*:/i);
     if (note) {
       for (const id of note[1].split(',').map((item) => item.trim()).filter(Boolean)) {
         if (!/^[A-Za-z_][\w.]*$/.test(id)) failClosed(line, 'unsupported sequence note participant syntax');
-        participants.add(id);
+        addEntity(entities, id, { diagramKind: 'interaction', participantKind: 'implicit', actor: false });
       }
       continue;
     }
     const message = line.match(/^([A-Za-z_][\w.]*)\s*-{1,2}(?:>>|>|x|\))\s*([A-Za-z_][\w.]*)\s*:/);
     if (message) {
-      participants.add(message[1]);
-      participants.add(message[2]);
+      addEntity(entities, message[1], { diagramKind: 'interaction', participantKind: 'implicit', actor: false });
+      addEntity(entities, message[2], { diagramKind: 'interaction', participantKind: 'implicit', actor: false });
+      addRelationship(relationships, message[1], message[2], { diagramKind: 'interaction' });
       messages += 1;
       continue;
     }
     failClosed(line, 'unsupported sequence syntax');
   }
-  assertLimit(participants.size, args.maxParticipants, 'Participant');
+  assertLimit(entities.size, args.maxParticipants, 'Participant');
   assertLimit(messages, args.maxMessages, 'Message');
   return {
-    counts: { participants: participants.size, messages },
+    counts: { participants: entities.size, messages },
     limits: { maxParticipants: args.maxParticipants, maxMessages: args.maxMessages },
+    groupedOrSplit: false,
+    elements: [...entities.values(), ...relationships.values()],
   };
 }
 
-function countEr(source, headerIndex, args) {
-  const entities = new Set();
-  let relationships = 0;
+function analyzeEr(source, headerIndex, args) {
+  const entities = new Map();
+  const relationships = new Map();
+  let relationshipLines = 0;
   let inEntity = null;
   for (const { line } of bodyLines(source, headerIndex)) {
     if (inEntity) {
@@ -285,35 +375,35 @@ function countEr(source, headerIndex, args) {
     }
     const block = line.match(/^([A-Za-z_][\w-]*)\s*\{$/);
     if (block) {
-      entities.add(block[1]);
+      addEntity(entities, block[1], { diagramKind: 'data-model' });
       inEntity = block[1];
       continue;
     }
     if (line === '}') failClosed(line, 'unmatched ER entity block close');
     const relationship = line.match(/^([A-Za-z_][\w-]*)\s+[|}{o]+\s*(?:--|\.\.)\s*[|}{o]+\s+([A-Za-z_][\w-]*)\s*:/);
     if (relationship) {
-      entities.add(relationship[1]);
-      entities.add(relationship[2]);
-      relationships += 1;
+      addEntity(entities, relationship[1], { diagramKind: 'data-model' });
+      addEntity(entities, relationship[2], { diagramKind: 'data-model' });
+      addRelationship(relationships, relationship[1], relationship[2], { diagramKind: 'data-model' });
+      relationshipLines += 1;
       continue;
     }
     failClosed(line, 'unsupported ER syntax');
   }
   if (inEntity) failClosed(inEntity, 'unclosed ER entity block');
   assertLimit(entities.size, args.maxEntities, 'Entity');
-  assertLimit(relationships, args.maxRelationships, 'Relationship');
+  assertLimit(relationshipLines, args.maxRelationships, 'Relationship');
   return {
-    counts: { entities: entities.size, relationships },
+    counts: { entities: entities.size, relationships: relationshipLines },
     limits: { maxEntities: args.maxEntities, maxRelationships: args.maxRelationships },
+    groupedOrSplit: false,
+    elements: [...entities.values(), ...relationships.values()],
   };
 }
 
-function addState(states, id) {
-  if (id !== '[*]') states.add(id);
-}
-
-function countState(source, headerIndex, args) {
-  const states = new Set();
+function analyzeState(source, headerIndex, args) {
+  const entities = new Map();
+  const relationships = new Map();
   let transitions = 0;
   for (const { line } of bodyLines(source, headerIndex)) {
     if (/^direction\s+(TB|BT|RL|LR)$/i.test(line)) continue;
@@ -322,33 +412,37 @@ function countState(source, headerIndex, args) {
     }
     const stateDecl = line.match(/^state\s+([A-Za-z_][\w.-]*)$/i);
     if (stateDecl) {
-      states.add(stateDecl[1]);
+      addEntity(entities, stateDecl[1], { diagramKind: 'state-model' });
       continue;
     }
     const transition = line.match(/^(\[\*\]|[A-Za-z_][\w.-]*)\s*-->\s*(\[\*\]|[A-Za-z_][\w.-]*)(?:\s*:\s*.+)?$/);
     if (transition) {
-      addState(states, transition[1]);
-      addState(states, transition[2]);
+      addEntity(entities, transition[1], { diagramKind: 'state-model' });
+      addEntity(entities, transition[2], { diagramKind: 'state-model' });
+      addRelationship(relationships, transition[1], transition[2], { diagramKind: 'state-model' });
       transitions += 1;
       continue;
     }
     const simpleState = line.match(/^([A-Za-z_][\w.-]*)(?:\s*:\s*.+)?$/);
     if (simpleState) {
-      states.add(simpleState[1]);
+      addEntity(entities, simpleState[1], { diagramKind: 'state-model' });
       continue;
     }
     failClosed(line, 'unsupported state syntax');
   }
-  assertLimit(states.size, args.maxStates, 'State');
+  assertLimit(entities.size, args.maxStates, 'State');
   assertLimit(transitions, args.maxTransitions, 'Transition');
   return {
-    counts: { states: states.size, transitions },
+    counts: { states: entities.size, transitions },
     limits: { maxStates: args.maxStates, maxTransitions: args.maxTransitions },
+    groupedOrSplit: false,
+    elements: [...entities.values(), ...relationships.values()],
   };
 }
 
-function countClass(source, headerIndex, args) {
-  const types = new Set();
+function analyzeClass(source, headerIndex, args) {
+  const entities = new Map();
+  const relationships = new Map();
   let relationshipLines = 0;
   let memberLines = 0;
   let inClass = null;
@@ -367,26 +461,27 @@ function countClass(source, headerIndex, args) {
     }
     const block = line.match(/^class\s+([A-Za-z_][\w.-]*)\s*\{$/i);
     if (block) {
-      types.add(block[1]);
+      addEntity(entities, block[1], { diagramKind: 'type-structure' });
       inClass = block[1];
       continue;
     }
     const declaration = line.match(/^class\s+([A-Za-z_][\w.-]*)$/i);
     if (declaration) {
-      types.add(declaration[1]);
+      addEntity(entities, declaration[1], { diagramKind: 'type-structure' });
       continue;
     }
     if (line === '}') failClosed(line, 'unmatched class block close');
     const relationship = line.match(/^([A-Za-z_][\w.-]*)\s+(<\|--|<\|\.\.|\*--|o--|-->|--|\.\.>|\.\.\|>|\.\.)\s+([A-Za-z_][\w.-]*)(?:\s*:.*)?$/);
     if (relationship) {
-      types.add(relationship[1]);
-      types.add(relationship[3]);
+      addEntity(entities, relationship[1], { diagramKind: 'type-structure' });
+      addEntity(entities, relationship[3], { diagramKind: 'type-structure' });
+      addRelationship(relationships, relationship[1], relationship[3], { diagramKind: 'type-structure' });
       relationshipLines += 1;
       continue;
     }
     const member = line.match(/^([A-Za-z_][\w.-]*)\s*:\s*.+$/);
     if (member) {
-      types.add(member[1]);
+      addEntity(entities, member[1], { diagramKind: 'type-structure' });
       memberLines += 1;
       continue;
     }
@@ -394,32 +489,299 @@ function countClass(source, headerIndex, args) {
   }
   if (inClass) failClosed(inClass, 'unclosed class block');
   const relationshipOrMemberLines = relationshipLines + memberLines;
-  assertLimit(types.size, args.maxTypes, 'Type');
+  assertLimit(entities.size, args.maxTypes, 'Type');
   assertLimit(relationshipOrMemberLines, args.maxMemberLines, 'Relationship/member line');
   return {
-    counts: { types: types.size, relationshipLines, memberLines, relationshipOrMemberLines },
+    counts: { types: entities.size, relationshipLines, memberLines, relationshipOrMemberLines },
     limits: { maxTypes: args.maxTypes, maxMemberLines: args.maxMemberLines },
+    groupedOrSplit: false,
+    elements: [...entities.values(), ...relationships.values()],
   };
 }
 
-function countDiagram(source, detected, args, text) {
-  if (detected.diagramKind === 'architecture') {
-    const topLevelNodes = countTopLevelNodes(source);
-    const groupedOrSplit = args.grouped || args.split || /techne-viz:\s*(grouped|split)\s*=\s*true/i.test(text);
-    if (topLevelNodes > args.maxNodes && !groupedOrSplit) {
-      throw new Error(`Top-level node count ${topLevelNodes} exceeds max ${args.maxNodes}; group into subgraphs or mark grouped/split`);
-    }
-    return {
-      counts: { topLevelNodes },
-      limits: { maxNodes: args.maxNodes },
-      groupedOrSplit,
-    };
-  }
-  if (detected.diagramKind === 'interaction') return { ...countSequence(source, detected.headerIndex, args), groupedOrSplit: false };
-  if (detected.diagramKind === 'data-model') return { ...countEr(source, detected.headerIndex, args), groupedOrSplit: false };
-  if (detected.diagramKind === 'state-model') return { ...countState(source, detected.headerIndex, args), groupedOrSplit: false };
-  if (detected.diagramKind === 'type-structure') return { ...countClass(source, detected.headerIndex, args), groupedOrSplit: false };
+function analyzeDiagram(source, detected, args, text) {
+  if (detected.diagramKind === 'architecture') return analyzeArchitecture(source, detected.headerIndex, args, text);
+  if (detected.diagramKind === 'interaction') return analyzeSequence(source, detected.headerIndex, args);
+  if (detected.diagramKind === 'data-model') return analyzeEr(source, detected.headerIndex, args);
+  if (detected.diagramKind === 'state-model') return analyzeState(source, detected.headerIndex, args);
+  if (detected.diagramKind === 'type-structure') return analyzeClass(source, detected.headerIndex, args);
   throw new Error(`Unsupported diagram kind: ${detected.diagramKind}`);
+}
+
+function parseCitation(token, lineNumber) {
+  const hash = token.indexOf('#');
+  const rawPath = hash === -1 ? token : token.slice(0, hash);
+  const symbol = hash === -1 ? null : token.slice(hash + 1);
+  if (!rawPath) throw new Error(`Invalid techne:source path on line ${lineNumber}`);
+  if (symbol !== null && !symbol) throw new Error(`Invalid empty techne:source symbol on line ${lineNumber}`);
+  if (symbol !== null && !/^[^\s]+$/.test(symbol)) throw new Error(`Invalid techne:source symbol on line ${lineNumber}; symbols must be printable non-whitespace`);
+  return { rawPath, symbol };
+}
+
+function parseAnnotations(source) {
+  const annotations = { sources: [], inferred: [] };
+  for (const { raw, line, index } of contentLines(source)) {
+    if (!line.startsWith('%%')) continue;
+    const techne = line.match(/^%%\s*techne:(\S+)\s*(.*)$/);
+    if (!techne) continue;
+    const directive = techne[1];
+    const rest = techne[2].trim();
+    if (directive === 'source') {
+      const parts = rest.split(/\s+/).filter(Boolean);
+      if (parts.length !== 2) throw new Error(`Malformed techne:source on line ${index + 1}; expected: %% techne:source <elementRef> <path>[#symbol]`);
+      annotations.sources.push({
+        directive,
+        line: index + 1,
+        raw,
+        ref: parts[0],
+        citation: parseCitation(parts[1], index + 1),
+      });
+      continue;
+    }
+    if (directive === 'inferred') {
+      const match = rest.match(/^(\S+)\s+(.+)$/);
+      if (!match) throw new Error(`Malformed techne:inferred on line ${index + 1}; expected: %% techne:inferred <relationshipRef> <reason>`);
+      annotations.inferred.push({
+        directive,
+        line: index + 1,
+        raw,
+        ref: match[1],
+        reason: match[2].trim(),
+      });
+      continue;
+    }
+    throw new Error(`Unknown reserved techne directive on line ${index + 1}: techne:${directive}`);
+  }
+  return annotations;
+}
+
+function normalizeProjectPath(rawPath) {
+  if (path.posix.isAbsolute(rawPath) || rawPath.includes('\\')) {
+    return { error: 'path must be POSIX-style relative to the project root' };
+  }
+  const normalized = path.posix.normalize(rawPath);
+  if (!normalized || normalized === '..' || normalized.startsWith('../')) {
+    return { error: 'path escapes the project root' };
+  }
+  return { normalized };
+}
+
+function resolveInsideRoot(projectRoot, normalized) {
+  const target = path.resolve(projectRoot, ...normalized.split('/'));
+  const relative = path.relative(projectRoot, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return { error: 'path escapes the project root' };
+  }
+  return { target };
+}
+
+function realpathInsideRoot(projectRoot, target) {
+  const realTarget = fs.realpathSync(target);
+  const relative = path.relative(projectRoot, realTarget);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return { error: 'source path resolves outside the project root' };
+  }
+  return { realTarget };
+}
+
+function addFailure(failures, ref, kind, message, extra = {}) {
+  failures.push({ ref, kind, message, ...extra });
+}
+
+function isWordChar(value) {
+  return WORD_CHAR_RE.test(value);
+}
+
+function containsSymbol(text, symbol) {
+  let start = text.indexOf(symbol);
+  while (start !== -1) {
+    const end = start + symbol.length;
+    const first = symbol[0];
+    const last = symbol[symbol.length - 1];
+    const leftOk = !isWordChar(first) || start === 0 || !isWordChar(text[start - 1]);
+    const rightOk = !isWordChar(last) || end >= text.length || !isWordChar(text[end]);
+    if (leftOk && rightOk) return true;
+    start = text.indexOf(symbol, start + 1);
+  }
+  return false;
+}
+
+function isArchitectureNode(element) {
+  return element.kind === 'entity' && element.diagramKind === 'architecture';
+}
+
+function isActorParticipant(element) {
+  return element.kind === 'entity' && element.diagramKind === 'interaction' && element.actor === true;
+}
+
+function verifySourceAnnotation(annotation, element, projectRoot, failures) {
+  const { rawPath, symbol } = annotation.citation;
+  const normalizedResult = normalizeProjectPath(rawPath);
+  if (normalizedResult.error) {
+    addFailure(failures, annotation.ref, 'invalid_path', normalizedResult.error, { line: annotation.line, path: rawPath });
+    return null;
+  }
+  const normalizedPath = normalizedResult.normalized;
+  const resolved = resolveInsideRoot(projectRoot, normalizedPath);
+  if (resolved.error) {
+    addFailure(failures, annotation.ref, 'invalid_path', resolved.error, { line: annotation.line, path: rawPath });
+    return null;
+  }
+  if (!fs.existsSync(resolved.target)) {
+    addFailure(failures, annotation.ref, 'missing_path', 'source path does not exist', { line: annotation.line, path: normalizedPath });
+    return null;
+  }
+  const realResolved = realpathInsideRoot(projectRoot, resolved.target);
+  if (realResolved.error) {
+    addFailure(failures, annotation.ref, 'invalid_path', realResolved.error, { line: annotation.line, path: normalizedPath });
+    return null;
+  }
+  const stats = fs.statSync(resolved.target);
+  if (stats.isDirectory()) {
+    if (symbol) {
+      addFailure(failures, annotation.ref, 'citation_strength', 'directory citations cannot include #symbol', { line: annotation.line, path: normalizedPath });
+      return null;
+    }
+    if (!isArchitectureNode(element)) {
+      addFailure(failures, annotation.ref, 'citation_strength', 'directory citations are valid only for architecture nodes', { line: annotation.line, path: normalizedPath });
+      return null;
+    }
+    return { strength: 'pathVerified', path: normalizedPath };
+  }
+  if (!stats.isFile()) {
+    addFailure(failures, annotation.ref, 'invalid_path', 'source path must be a file or directory', { line: annotation.line, path: normalizedPath });
+    return null;
+  }
+  if (!symbol) {
+    if (isArchitectureNode(element) || isActorParticipant(element)) {
+      return { strength: 'pathVerified', path: normalizedPath };
+    }
+    addFailure(failures, annotation.ref, 'citation_strength', 'file path-only citations are valid only for architecture nodes and actor participants', { line: annotation.line, path: normalizedPath });
+    return null;
+  }
+  const text = fs.readFileSync(realResolved.realTarget, 'utf8');
+  if (!containsSymbol(text, symbol)) {
+    addFailure(failures, annotation.ref, 'symbol_not_found', 'symbol was not found in source file', { line: annotation.line, path: normalizedPath, symbol });
+    return null;
+  }
+  return { strength: 'symbolVerified', path: normalizedPath, symbol };
+}
+
+function bestStrength(records) {
+  if (records.some((record) => record.strength === 'symbolVerified')) return 'symbolVerified';
+  if (records.some((record) => record.strength === 'pathVerified')) return 'pathVerified';
+  return null;
+}
+
+function validateProvenance({ annotations, elements, projectRoot }) {
+  const map = elementMap(elements);
+  const failures = [];
+  const sourceRecords = new Map(elements.map((element) => [element.ref, []]));
+  const inferredRefs = new Set();
+
+  for (const annotation of annotations.sources) {
+    const element = map.get(annotation.ref);
+    if (!element) {
+      addFailure(failures, annotation.ref, 'unknown_ref', 'annotation references an element not present in the diagram', { line: annotation.line });
+      continue;
+    }
+    if (element.kind === 'relationship' && !annotation.citation.symbol) {
+      addFailure(failures, annotation.ref, 'citation_strength', 'relationship-like source annotations require #symbol', { line: annotation.line, path: annotation.citation.rawPath });
+      continue;
+    }
+    const verified = verifySourceAnnotation(annotation, element, projectRoot, failures);
+    if (verified) sourceRecords.get(annotation.ref).push(verified);
+  }
+
+  const entityStatus = new Map();
+  for (const element of elements.filter((item) => item.kind === 'entity')) {
+    const strength = bestStrength(sourceRecords.get(element.ref) || []);
+    if (strength) {
+      entityStatus.set(element.ref, strength);
+    } else {
+      entityStatus.set(element.ref, 'uncovered');
+      addFailure(failures, element.ref, 'uncovered', 'entity-like element requires a verified techne:source');
+    }
+  }
+
+  for (const annotation of annotations.inferred) {
+    const element = map.get(annotation.ref);
+    if (!element) {
+      addFailure(failures, annotation.ref, 'unknown_ref', 'annotation references an element not present in the diagram', { line: annotation.line });
+      continue;
+    }
+    if (element.kind !== 'relationship') {
+      addFailure(failures, annotation.ref, 'invalid_inferred', 'techne:inferred is valid only for relationship-like elements', { line: annotation.line });
+      continue;
+    }
+    const missingEndpoint = element.endpoints.find((endpoint) => endpoint !== '[*]' && entityStatus.get(endpoint) === 'uncovered');
+    if (missingEndpoint) {
+      addFailure(failures, annotation.ref, 'invalid_inferred', `inferred relationship endpoint is not sourced: ${missingEndpoint}`, { line: annotation.line });
+      continue;
+    }
+    inferredRefs.add(annotation.ref);
+  }
+
+  const elementStatuses = new Map();
+  for (const element of elements) {
+    const sourceStrength = bestStrength(sourceRecords.get(element.ref) || []);
+    if (element.kind === 'entity') {
+      elementStatuses.set(element.ref, sourceStrength || 'uncovered');
+      continue;
+    }
+    if (sourceStrength === 'symbolVerified') {
+      elementStatuses.set(element.ref, 'symbolVerified');
+    } else if (inferredRefs.has(element.ref)) {
+      elementStatuses.set(element.ref, 'inferred');
+    } else {
+      elementStatuses.set(element.ref, 'uncovered');
+      addFailure(failures, element.ref, 'uncovered', 'relationship-like element requires a symbol-verified techne:source or valid techne:inferred');
+    }
+  }
+
+  const coverage = {
+    elements: elements.length,
+    symbolVerified: 0,
+    pathVerified: 0,
+    inferred: 0,
+    uncovered: 0,
+    ratio: 0,
+  };
+  for (const status of elementStatuses.values()) {
+    if (status === 'symbolVerified') coverage.symbolVerified += 1;
+    else if (status === 'pathVerified') coverage.pathVerified += 1;
+    else if (status === 'inferred') coverage.inferred += 1;
+    else coverage.uncovered += 1;
+  }
+  coverage.ratio = coverage.elements ? Number((coverage.symbolVerified / coverage.elements).toFixed(2)) : 0;
+
+  const sourceFiles = uniqueSorted([...sourceRecords.values()].flat().map((record) => record.path));
+  return {
+    ok: failures.length === 0,
+    coverage,
+    sourceFiles,
+    provenance: {
+      verified: failures.length === 0,
+      failures,
+      annotations: {
+        sources: annotations.sources.length,
+        inferred: annotations.inferred.length,
+      },
+    },
+  };
+}
+
+function unverifiedProvenance(annotations) {
+  return {
+    provenance: {
+      verified: false,
+      failures: [],
+      annotations: {
+        sources: annotations.sources.length,
+        inferred: annotations.inferred.length,
+      },
+    },
+  };
 }
 
 async function main() {
@@ -427,9 +789,10 @@ async function main() {
   const text = fs.readFileSync(args.file, 'utf8');
   const source = extractMermaid(text);
   const detected = detectType(source);
+  const annotations = parseAnnotations(source);
   const mermaid = await loadMermaid(findNodeModules(process.cwd()));
   await mermaid.parse(source, { suppressErrors: false });
-  const measured = countDiagram(source, detected, args, text);
+  const measured = analyzeDiagram(source, detected, args, text);
   const output = {
     ok: true,
     diagramKind: detected.diagramKind,
@@ -440,10 +803,35 @@ async function main() {
     groupedOrSplit: measured.groupedOrSplit,
   };
   Object.assign(output, measured.counts);
+
+  if (args.project) {
+    const projectPath = path.resolve(args.project);
+    if (!fs.existsSync(projectPath) || !fs.statSync(projectPath).isDirectory()) {
+      throw new Error(`Project directory does not exist: ${projectPath}`);
+    }
+    const projectRoot = fs.realpathSync(projectPath);
+    const provenance = validateProvenance({ annotations, elements: measured.elements, projectRoot });
+    Object.assign(output, {
+      provenance: provenance.provenance,
+      coverage: provenance.coverage,
+      sourceFiles: provenance.sourceFiles,
+    });
+    if (!provenance.ok) {
+      output.ok = false;
+      throw new ProvenanceError(output);
+    }
+  } else {
+    Object.assign(output, unverifiedProvenance(annotations));
+  }
+
   console.log(JSON.stringify(output));
 }
 
 main().catch((error) => {
-  console.error(error.message || String(error));
+  if (error instanceof ProvenanceError) {
+    console.error(JSON.stringify(error.payload));
+  } else {
+    console.error(error.message || String(error));
+  }
   process.exit(1);
 });

--- a/skills/viz/scripts/viewer/template.html
+++ b/skills/viz/scripts/viewer/template.html
@@ -707,7 +707,7 @@ __TECHNE_SVG_PAN_ZOOM_JS__
             ["kind", getDiagramKind(item)],
             ["shape", item.shape],
             ["mermaid", getMermaidType(item)],
-            ["coverage", item.coverage],
+            ["coverage", formatCoverage(item.coverage)],
             ["nodes", item.nodeCount],
             ["generated", formatDate(item.generatedAt)],
             ["sources", sourceFiles.length ? sourceFiles.join(", ") : null],
@@ -717,6 +717,19 @@ __TECHNE_SVG_PAN_ZOOM_JS__
             .filter((entry) => entry[1] !== undefined && entry[1] !== null && entry[1] !== "")
             .map(([label, value]) => `<span class="meta-pill">${escapeHtml(label)}: ${escapeHtml(String(value))}</span>`)
             .join("");
+        }
+
+        function formatCoverage(value) {
+          if (!value) return null;
+          if (typeof value === "string") return value;
+          if (typeof value !== "object") return String(value);
+          const ratio = typeof value.ratio === "number" ? `${Math.round(value.ratio * 100)}%` : null;
+          const parts = [];
+          if (typeof value.symbolVerified === "number") parts.push(`symbol ${value.symbolVerified}`);
+          if (typeof value.pathVerified === "number") parts.push(`path ${value.pathVerified}`);
+          if (typeof value.inferred === "number") parts.push(`inferred ${value.inferred}`);
+          if (typeof value.uncovered === "number" && value.uncovered > 0) parts.push(`uncovered ${value.uncovered}`);
+          return [ratio, parts.join(" / ")].filter(Boolean).join(" - ");
         }
 
         function formatDate(value) {


### PR DESCRIPTION
Closes #20

## What changed

- Added `--project` provenance enforcement to `skills/viz/scripts/validate-mermaid.mjs`.
  - Parses `%% techne:source` and `%% techne:inferred`.
  - Fails closed on unknown `%% techne:*` directives.
  - Enumerates provenance elements for architecture, interaction, data-model, state-model, and type-structure diagrams.
  - Verifies project-root-relative paths, rejects `..` and symlink escapes, checks symbols with the documented boundary rule, and computes `coverage` plus derived `sourceFiles`.
- Reworked `skills/viz/scripts/store_viz.py` so store runs the validator and removes self-reported truth fields.
  - Removed `--source`, `--coverage`, `--node-count`, `--diagram-kind`, and `--type`.
  - Writes `diagramKind`, `type`, `sourceFiles`, `coverage`, `nodeCount`, and `topLevelNodes` from validator output.
  - Keeps `--grouped` / `--split` as readability policy flags.
- Updated the viewer template to display both legacy string coverage and new coverage objects.
- Updated `SKILL.md`, `reference.md`, `eval.md`, `README.md`, and `README-CN.md` for the new provenance contract and CLI surface.

## Mechanical self-checks run

- `node --check skills/viz/scripts/validate-mermaid.mjs` passed.
- `python3 -m py_compile skills/viz/scripts/store_viz.py skills/viz/scripts/build_viewer.py` passed earlier during implementation; generated `__pycache__` was removed.
- Temporary A-V provenance fixture suite passed: `SUMMARY pass=27 fail=0`.
  - Covered missing paths, missing symbols, zero annotations, valid source+symbol, valid inferred edge, unknown refs, `..` escape, five-kind no-`--project` regression, all-inferred bypass, unsourced inferred endpoint, directory citation rules, stale store args, missing deps, unknown `techne:*`, README path-only alibi, actor path-only allowance, non-actor path-only rejection, and derived sequence metadata.
- Extra path hardening fixture passed: symlink inside project pointing outside project is rejected.
- Store runtime failure checks passed:
  - Missing validator deps relays `Missing dependencies: install mermaid@11.15.0 and jsdom...`.
  - `node` absent from PATH returns an actionable Node.js requirement message.
- Store helper idempotently appends one `.techne/` entry to target project `.gitignore`.
- Viewer build fixture passed with both legacy string coverage and new object coverage embedded.
- `claude plugin validate . --strict` passed.
- `claude --bare --plugin-dir . plugin details techne` shows `techne` with skills `_template, viz`.
- `git diff --check` passed.
- `.techne/` generated output is not tracked or present in this repo.
- Secret scan found no secrets; only the existing AGENTS.md policy line matched the word `secrets`.

## Deferred to Claude / maintainer review

- Skill-level empirical faithfulness on real private/local repos.
- Spot-check that cited `path#symbol` evidence actually supports each diagram element, not merely grep-matches.
- Friction and Goodhart checks: the provenance contract should not make the model avoid useful nodes or choose common-word citations.
