### PR TITLE
docs: sync internal guidance to two-skill reality, record repro acceptance status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,14 +3,14 @@
 ```yaml
 version: v0.1
 project: techne
-updated: 2026-06-09
+updated: 2026-06-10
 ```
 
 ## Project Facts
 
 - `techne` is an early-stage skills/plugin repository for "Skills and agents for the AI era."
-- The current `main` branch contains the Claude plugin skin, install matrix docs, Cursor/Gemini thin skins, and the first real skill: `skills/viz`.
-- There is still no root app, root package manager, CI, or general test runner. `skills/viz/scripts/package.json` is a local helper manifest for the Mermaid validator, not a repo-wide build system.
+- The current `main` branch contains the Claude plugin skin, install matrix docs, Cursor/Gemini thin skins, and two real skills: `skills/viz` (typed diagram router with a mechanical provenance gate) and `skills/repro` (repro-first bugfix ledger).
+- There is still no root app, root package manager, CI, or general test runner. `skills/viz/scripts/package.json` is a local helper manifest for the Mermaid validator, not a repo-wide build system; `skills/repro/scripts/repro_ledger.py` is dependency-free Python 3 stdlib (POSIX-only).
 - The git history contains a legacy `atools-js` codebase, but new work in this repo should not infer current architecture, tooling, or business rules from that legacy history unless the user explicitly asks for migration or reference work.
 
 ## Working Rules
@@ -39,4 +39,5 @@ Non-trivial work follows [`WORKFLOW.md`](WORKFLOW.md) — read it before acting 
 - For documentation-only changes, run `git diff --check`.
 - For plugin packaging changes, run `claude plugin validate . --strict`; use `claude --bare --plugin-dir . plugin details techne` when you need to confirm skill discovery without opening an interactive Claude session.
 - For `skills/viz` script changes, run focused checks for the touched surface: `node skills/viz/scripts/validate-mermaid.mjs ...`, `python3 skills/viz/scripts/store_viz.py ...`, and `python3 skills/viz/scripts/build_viewer.py --project ...`; install or point `TECHNE_VIZ_NODE_MODULES` at `mermaid@11.15.0` + `jsdom` for validator checks.
+- For `skills/repro` script changes, run `python3 -m py_compile skills/repro/scripts/repro_ledger.py` and exercise the touched behavior against throwaway `/tmp` projects; the fixture table A–X in `skills/repro/eval.md` is the reference suite. The ledger must stay Python 3 stdlib and POSIX-only (macOS/Linux).
 - For code or executable assets, use the closest direct validation and state any empirical gap. Codex can mechanically validate scripts and packaging, but Claude/maintainer review judges skill faithfulness on real projects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,14 @@ contains:
   and the universal Agent Skills fallback.
 - `skills/viz/`, the first real skill: a typed diagram router for codebase
   architecture, request interactions, data models, state models, and type
-  structures.
+  structures, with a mechanical provenance gate.
+- `skills/repro/`, the second real skill: a repro-first bugfix gate that forces
+  fail → fix → same-probe verification through a run ledger.
 
 There is still **no root app, no root package manager, no CI, and no repo-wide
 test runner**. `skills/viz/scripts/package.json` only pins helper dependencies
-for that skill's Mermaid validator. Do not infer commands, dependencies, or
+for that skill's Mermaid validator; `skills/repro/scripts/repro_ledger.py` is
+dependency-free Python 3 stdlib (POSIX-only). Do not infer commands, dependencies, or
 architecture from the legacy library; that direction was abandoned.
 
 ## Project intent
@@ -35,7 +38,9 @@ install instructions that point back to that shared body.
 
 ## Current skill surface
 
-`skills/viz` is the active seeded skill.
+Two skills are seeded: `skills/viz` and `skills/repro`.
+
+`skills/viz` (coding/investigate):
 
 - `SKILL.md` forces the cognitive procedure: route the diagram kind, read real
   evidence, draw only evidenced relationships, enforce complexity gates, mark
@@ -44,16 +49,37 @@ install instructions that point back to that shared body.
   `data-model`, `state-model`, and `type-structure`.
 - Supported Mermaid types are `flowchart` / `graph`, `sequenceDiagram`,
   `erDiagram`, `stateDiagram-v2` / `stateDiagram`, and `classDiagram`.
-- `scripts/validate-mermaid.mjs` is parse-only plus counters. It intentionally
-  does **not** call `mermaid.render()` under Node/jsdom; browser rendering is
-  checked through the self-contained file viewer.
-- `scripts/store_viz.py` writes diagrams to a target project's
-  `.techne/viz/*.md` and `.index.json`, and idempotently adds `.techne/` to that
-  target project's `.gitignore`.
+- `scripts/validate-mermaid.mjs` parses and counts, and — with
+  `--project <root>` — mechanically verifies `%% techne:source` /
+  `%% techne:inferred` provenance annotations against the target project
+  (paths, symbols, citation strength) and computes coverage; without
+  `--project` it syntax-checks annotations only. It intentionally does **not**
+  call `mermaid.render()` under Node/jsdom; browser rendering is checked
+  through the self-contained file viewer.
+- `scripts/store_viz.py` runs the validator itself (provenance enforced, no
+  bypass flags) and derives `diagramKind`, `type`, `sourceFiles`, `coverage`,
+  and `nodeCount` from validator output — there are no self-reported metadata
+  flags. It writes diagrams to a target project's `.techne/viz/*.md` and
+  `.index.json`, and idempotently adds `.techne/` to that target project's
+  `.gitignore`.
 - `scripts/build_viewer.py` builds a self-contained `.techne/viz/index.html`.
   It does not start a server.
-- Generated `.techne/` output belongs in target projects and must not be
-  committed to this repository.
+
+`skills/repro` (coding/debug):
+
+- `SKILL.md` forces the cognitive procedure: trigger-check the task as a
+  behavioral bug, capture a stable `--expect` anchor, demonstrate the failure
+  through the ledger before editing, fix, verify with the byte-identical probe
+  identity, then report citing the `close` JSON and strength rung.
+- `scripts/repro_ledger.py` (Python 3 stdlib, POSIX/macOS/Linux only) executes
+  and records probes in a target project's `.techne/repro/<bug>.jsonl`.
+  Classification is computed, never declared: probe identity is
+  `{mode, argv | shellCommand, cwd, timeoutSec}`, and `close` exits 0 only on a
+  fail → later same-identity pass, or on a loud `mark-unreproduced`
+  speculative path.
+
+Generated `.techne/` output (viz and repro alike) belongs in target projects
+and must not be committed to this repository.
 
 ## Development workflow
 
@@ -73,8 +99,8 @@ validator needs `mermaid@11.15.0` and `jsdom` in `TECHNE_VIZ_NODE_MODULES`,
 `skills/viz/scripts/node_modules`, the current directory, or an ancestor:
 
 ```bash
-node skills/viz/scripts/validate-mermaid.mjs diagram.md --max-nodes 15
-python3 skills/viz/scripts/store_viz.py --project /tmp/project --name diagram --title "Diagram" --diagram diagram.md --shape monorepo --diagram-kind architecture --type flowchart
+node skills/viz/scripts/validate-mermaid.mjs diagram.md --project /tmp/project --max-nodes 15
+python3 skills/viz/scripts/store_viz.py --project /tmp/project --name diagram --title "Diagram" --diagram diagram.md --shape monorepo
 python3 skills/viz/scripts/build_viewer.py --project /tmp/project
 git diff --check
 ```
@@ -82,6 +108,15 @@ git diff --check
 For viewer work, also open the generated `file://.../.techne/viz/index.html`
 and verify the relevant diagrams render without console errors or external
 network loads.
+
+For `repro` script changes, exercise the ledger against throwaway `/tmp`
+projects — `skills/repro/eval.md` fixtures A–X are the reference suite:
+
+```bash
+python3 -m py_compile skills/repro/scripts/repro_ledger.py
+python3 skills/repro/scripts/repro_ledger.py run --project /tmp/project --bug demo --expect "boom" -- python3 -c 'print("boom"); raise SystemExit(1)'
+python3 skills/repro/scripts/repro_ledger.py status --project /tmp/project --bug demo
+```
 
 ## Legacy code
 

--- a/skills/repro/eval.md
+++ b/skills/repro/eval.md
@@ -4,6 +4,16 @@
 mechanical fixtures test the ledger. The empirical gate tests the skill inside a
 real Claude context before merge.
 
+## Acceptance Status
+
+- 2026-06-10 — Mechanical fixtures A–X: **passed**, twice independently — in PR
+  #23's self-check and re-verified in the Claude review (24/24, plus fresh-eyes
+  probes and a realistic end-to-end fail → fix → verify cycle).
+- 2026-06-10 — Empirical acceptance (3 seeded historical bugs, baseline vs
+  skill, controls C1–C3): **not yet run**. PR #23 merged ahead of this gate;
+  the results are owed and will be recorded here and on issue #22 when the
+  protocol runs. Until then, `repro` has not cleared its own empirical bar.
+
 ## Mechanical Fixtures
 
 All fixtures must pass in the PR with throwaway projects under `/tmp`.


### PR DESCRIPTION
## What

Light-path docs fix for the three failing findings from the post-merge documentation audit:

1. **CLAUDE.md** was double-stale: it described `skills/viz` as the only seeded skill and `validate-mermaid.mjs` as "parse-only plus counters" — both pre-P0 descriptions. Worse, its baseline command still passed `--diagram-kind`/`--type`, flags that `store_viz.py` removed in #21 (argparse rejects them with exit 2 — the documented command fails if run). Now: both skills listed with their mechanical gates, validator `--project` provenance mode described, store baseline fixed, `repro_ledger.py` baseline added.
2. **AGENTS.md** (codex's entry doc): "the first real skill: skills/viz" → two-skill project facts, plus a `skills/repro` verification path (py_compile + eval.md fixture table A–X as reference suite), date bump.
3. **skills/repro/eval.md** gains an **Acceptance Status** section: mechanical fixtures passed twice independently (PR #23 self-check + Claude review 24/24), while the empirical gate (3 seeded historical bugs, baseline vs skill, C1–C3) has **not yet run** — #23 merged ahead of that gate, so the doc now records the debt instead of contradicting history. Results will be appended there and on #22 when the protocol runs.

## Verification

- `claude plugin validate . --strict` ✔
- `git diff --check` ✔
- Docs-only change; no skill bodies or scripts touched.

Per WORKFLOW light path: direct change + one cross-check. codex (or maintainer eyeball) cross-checks, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)