### PR TITLE
docs: cross-skill Validation Status ledger + honest empirical-debt tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,6 +99,29 @@ briefs through a fixed rubric before work starts, surfacing gaps,
 solution-as-goal traps, contradictions, and dependent questions before emitting
 an intent-level plan.
 
+## Validation Status
+
+Per [`WORKFLOW.md`](WORKFLOW.md), a skill clears two gates: **step 4** mechanical
+review and **step 5** empirical acceptance — baseline vs. with-skill, judged
+jointly, on the principle `changing ≠ improving`. All four seeded skills merged
+**ahead of step 5**; the empirical proof is **owed** and is run **manually by the
+maintainer in real projects**. This table is the durable tracker: issue-based
+tracking has eroded — two tracking issues were closed with the debt still
+carried — so trust this ledger, not issue state.
+
+| Skill | Step 4 — mechanical | Step 5 — empirical | Tracking issue | Methodology |
+| --- | --- | --- | --- | --- |
+| `viz` | passed (merged) | **not recorded — owed** | #11 closed (build PR; no dedicated empirical issue) | [`skills/viz/eval.md`](skills/viz/eval.md) |
+| `repro` | passed (24/24 + review probes) | **not run — owed** | #22 closed 2026-06-10 (debt carried) | [`skills/repro/eval.md`](skills/repro/eval.md) |
+| `vet` | passed (56/56) | **not run — owed** | #25 closed 2026-06-13 (debt carried) | [`skills/vet/eval.md`](skills/vet/eval.md) |
+| `intake` | passed (21/21 + review probes) | **not run — owed** | #28 open | [`skills/intake/eval.md`](skills/intake/eval.md) |
+
+Discharging a skill's step-5 debt: run its `eval.md` empirical protocol (baseline
+vs. with-skill over seeded real-project material against a maintainer answer key),
+record the result in that `eval.md` Acceptance Status, and update the row above.
+Closing a tracking issue does **not** discharge the debt; only a recorded result
+does.
+
 ## Packaging Status
 
 techne now ships one shared `skills/` body through multiple thin paths:

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,7 +1,7 @@
 ```yaml
 version: v0.1
 project: techne
-updated: 2026-06-09
+updated: 2026-06-14
 ```
 
 # Workflow
@@ -79,6 +79,10 @@ your side, and never closes end-to-end on codex.
 otherwise skip the move, forcing it *improves* the outcome. Judge jointly. Finance
 has delayed ground truth, so backtest against history; elsewhere, blind
 baseline-vs-skill.
+
+Per-skill validation status lives in [`ROADMAP.md`](ROADMAP.md) Validation Status
+— the durable tracker. Issue state is **not** authoritative for empirical debt: a
+closed tracking issue does not mean the step-5 gate was cleared.
 
 ## How this doc earns its place
 

--- a/skills/intake/eval.md
+++ b/skills/intake/eval.md
@@ -9,8 +9,10 @@ tests the skill in a real Claude context before issue #28 is closed.
 - 2026-06-13 — Mechanical fixtures A-L, floor fixtures, and house fixtures:
   **passed in the implementation PR self-check** against throwaway `/tmp`
   projects (`21/21 passed`).
-- 2026-06-13 — Empirical acceptance: **not yet run**. This issue must remain
-  open until results are recorded here and in an issue comment for #28.
+- 2026-06-13 — Empirical acceptance: **not yet run**, owed. Tracking issue #28
+  remains open; the result will be recorded here and in an issue comment for #28.
+  Durable cross-skill tracker: `ROADMAP.md` Validation Status. Verification is
+  run manually by the maintainer in real projects.
 
 ## Mechanical Fixtures
 

--- a/skills/repro/eval.md
+++ b/skills/repro/eval.md
@@ -10,9 +10,11 @@ real Claude context before merge.
   #23's self-check and re-verified in the Claude review (24/24, plus fresh-eyes
   probes and a realistic end-to-end fail → fix → verify cycle).
 - 2026-06-10 — Empirical acceptance (3 seeded historical bugs, baseline vs
-  skill, controls C1–C3): **not yet run**. PR #23 merged ahead of this gate;
-  the results are owed and will be recorded here and on issue #22 when the
-  protocol runs. Until then, `repro` has not cleared its own empirical bar.
+  skill, controls C1–C3): **not yet run**, owed. PR #23 merged ahead of this
+  gate. Tracking issue #22 was closed (2026-06-10) with this debt still carried,
+  so the durable tracker is `ROADMAP.md` Validation Status; the result will be
+  recorded here on manual verification. Until then, `repro` has not cleared its
+  own empirical bar.
 
 ## Mechanical Fixtures
 

--- a/skills/vet/eval.md
+++ b/skills/vet/eval.md
@@ -12,8 +12,10 @@ real Claude review context before the issue is closed.
 - 2026-06-13 — PR #26 step-4 follow-up added fixtures AI-AJ for removed-side
   symbols, Python f-string masking, and early-stop symmetry; the full fixture
   suite passed against throwaway `/tmp` projects (`56/56 passed`).
-- 2026-06-12 — Empirical acceptance: **not yet run**. This issue must remain
-  open until results are recorded here and in an issue comment for #25.
+- 2026-06-12 — Empirical acceptance: **not yet run**, owed. Tracking issue #25
+  was closed (2026-06-13) with this debt still carried; the durable tracker is
+  `ROADMAP.md` Validation Status, and the result will be recorded here on manual
+  verification.
 
 ## Mechanical Fixtures
 

--- a/skills/viz/eval.md
+++ b/skills/viz/eval.md
@@ -4,6 +4,18 @@ This is the empirical acceptance methodology. Codex only runs mechanical checks;
 Claude and the maintainer run the skill-level evaluation in an authenticated
 Claude context.
 
+## Acceptance Status
+
+- `viz` shipped through the build work tracked in #11 (closed 2026-06-08). Its
+  mechanical provenance methodology is in "Mechanical Provenance Fixtures" below.
+- 2026-06-14 — Empirical acceptance (baseline vs. with-`viz`, per the Test Set,
+  Metrics, and Pass Bar below): **no result is recorded**. Like `repro`, `vet`,
+  and `intake`, `viz` merged ahead of a recorded step-5 result, and it has no
+  dedicated open tracking issue. Until a run is recorded here, `viz` has not
+  demonstrably cleared its empirical bar. Verification is owed and is run
+  manually by the maintainer in real projects. Durable cross-skill tracker:
+  `ROADMAP.md` Validation Status.
+
 ## Test Set
 
 Use maintainer-private local repos or bounded areas that cover the supported


### PR DESCRIPTION
Doc-only bookkeeping. Adds a durable **Validation Status** ledger to `ROADMAP.md` tracking step-4 (mechanical) and step-5 (empirical) status for all four skills — needed because issue state is no longer authoritative: #22 (repro) and #25 (vet) were closed with the step-5 empirical debt still owed, and #11 (viz) was only the build PR.

- `ROADMAP.md`: new Validation Status table + discharge instructions.
- `skills/viz/eval.md`: add the missing Acceptance Status stamp.
- `skills/repro/eval.md`, `skills/vet/eval.md`: correct the now-false "this issue must remain open" lines (issues are closed; debt carried; point to the ledger).
- `skills/intake/eval.md`: point at the ledger (#28 still open).
- `WORKFLOW.md`: link the ledger; state that a closed issue != step-5 cleared.

No skill behavior or plugin-skin files touched. Empirical verification remains owed and will be run manually by the maintainer in real projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)